### PR TITLE
Fix Wikilinks, Identifier Links

### DIFF
--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -4,7 +4,7 @@
   import { naddrEncode } from 'nostr-tools/nip19';
 
   import { account, reactionKind, _pool, wikiKind, signer } from '$lib/nostr';
-  import { formatDate, getA, getTagOr, next, normalizeArticleName } from '$lib/utils';
+  import { formatDate, getA, getTagOr, next, normalizeIdentifier } from '$lib/utils';
   import type { ArticleCard, SearchCard, Card } from '$lib/types';
   import UserLabel from '$components/UserLabel.svelte';
   import ArticleContent from '$components/ArticleContent.svelte';
@@ -66,7 +66,7 @@
     if (
       articleCard.back &&
       event &&
-      normalizeArticleName(articleCard.back.data) === getTagOr(event, 'd')
+      normalizeIdentifier(articleCard.back.data) === getTagOr(event, 'd')
     ) {
       // just go back
       back();
@@ -290,7 +290,6 @@
           {#if event.created_at}
             {formatDate(event.created_at)}
           {/if}
-          <!-- svelte-ignore a11y-no-static-element-interactions a11y-click-events-have-key-events a11y-missing-attribute -->
         </div>
         <div>
           <a class="cursor-pointer underline" on:click={edit}>

--- a/src/cards/Editor.svelte
+++ b/src/cards/Editor.svelte
@@ -3,7 +3,6 @@
   import { onMount } from 'svelte';
   import SvelteAsciidoc from 'svelte-asciidoc';
 
-  import ArticleContent from '$components/ArticleContent.svelte';
   import WikilinkComponent from '$components/WikilinkComponent.svelte';
   import { DEFAULT_WIKI_RELAYS } from '$lib/defaults';
   import { loadRelayList } from '$lib/lists';
@@ -12,7 +11,7 @@
   import {
     getTagOr,
     next,
-    normalizeArticleName,
+    normalizeIdentifier,
     turnWikilinksIntoAsciidocLinks,
     unique,
     urlWithoutScheme
@@ -43,7 +42,7 @@
 
     let eventTemplate: EventTemplate = {
       kind: wikiKind,
-      tags: [['d', normalizeArticleName(data.title)]],
+      tags: [['d', normalizeIdentifier(data.title)]],
       content: data.content.trim(),
       created_at: Math.round(Date.now() / 1000)
     };

--- a/src/cards/New.svelte
+++ b/src/cards/New.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { next, normalizeArticleName } from '$lib/utils';
+  import { next, normalizeIdentifier } from '$lib/utils';
   import type { SearchCard, Card } from '$lib/types';
 
   export let replaceNewCard: (card: Card) => void;
@@ -10,7 +10,7 @@
       const newCard: SearchCard = {
         id: next(),
         type: 'find',
-        data: normalizeArticleName(query),
+        data: normalizeIdentifier(query),
         preferredAuthors: []
       };
       replaceNewCard(newCard);

--- a/src/components/WikilinkComponent.svelte
+++ b/src/components/WikilinkComponent.svelte
@@ -21,7 +21,22 @@
 
   function handleWikilinkClick() {
     if (createChild) {
-      createChild({ id: next(), type: 'find', data: wikitarget, preferredAuthors } as SearchCard);
+      // Decode HTML entities: preserve double dashes and remove zero-width spaces
+      const decoded = wikitarget.replace(/&[#\w]+;/g, (match) => {
+        // Preserve double dashes
+        if (match === '&#8212;') {
+          return '--';
+        }
+
+        // Remove zero-width spaces
+        if (match === '&#8203;') {
+          return '';
+        }
+
+        return match;
+      });
+
+      createChild({ id: next(), type: 'find', data: decoded, preferredAuthors } as SearchCard);
     }
   }
 </script>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -90,8 +90,24 @@ export function getParentCard(el: HTMLElement): HTMLElement | null {
   return curr;
 }
 
-export function normalizeArticleName(input: string): string {
-  return input.trim().toLowerCase().replace(/\W/g, '-');
+export function normalizeIdentifier(name: string): string {
+  // Trim and lowercase
+  name = name.trim().toLowerCase();
+  
+  // Normalize Unicode to NFKC form
+  name = name.normalize('NFKC');
+  
+  // Convert to array of characters and map each one
+  return Array.from(name)
+    .map(char => {
+      // Check if character is letter or number using Unicode ranges
+      if (/\p{Letter}/u.test(char) || /\p{Number}/u.test(char)) {
+        return char;
+      }
+      
+      return '-';
+    })
+    .join('');
 }
 
 export function getA(event: NostrEvent) {
@@ -163,7 +179,7 @@ export function turnWikilinksIntoAsciidocLinks(content: string): string {
   return content.replace(/\[\[(.*?)\]\]/g, (_: any, content: any) => {
     let [target, display] = content.split('|');
     display = display || target;
-    target = normalizeArticleName(target);
+    target = normalizeIdentifier(target);
     return `link:wikilink:${target}[${display}]`;
   });
 }


### PR DESCRIPTION
introduced normalizeIdentifier to keep unicode chars (removed normalizeArticleName)
fixed a bug in the svelte component escaping target with html entities (keep double dash, remove empty space char)