### PR TITLE
Wikistr Article Lookup, Auto-Redirect, and Collapsible Layout

### DIFF
--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -751,7 +751,7 @@
 
       <!-- Table of Contents -->
       {#if headings.length > 0}
-        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 max-w-sm">
+        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 w-full max-w-full sm:max-w-md lg:max-w-lg">
           <div class="text-xs font-bold text-stone-700 uppercase tracking-wider mb-2 border-b border-stone-200 pb-1 flex justify-between items-center">
             <span>Table of Contents</span>
           </div>

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -751,7 +751,7 @@
 
       <!-- Table of Contents -->
       {#if headings.length > 0}
-        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 w-full">
+        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 w-full max-w-none" style="width: 100% !important; max-width: none !important;">
           <div class="text-xs font-bold text-stone-700 uppercase tracking-wider mb-2 border-b border-stone-200 pb-1 flex justify-between items-center">
             <span>Table of Contents</span>
           </div>

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -52,20 +52,33 @@
     if (!event?.content) return [];
     const lines = event.content.split(/\r?\n/);
     const list: Heading[] = [];
+    
+    const hasAsciiDocHeadings = lines.some(line => line.match(/^={2,6}\s+.+$/));
+    let inCodeBlock = false;
+
     lines.forEach((line) => {
-      const adMatch = line.match(/^(=+)\s+(.+)$/);
-      if (adMatch) {
-        const level = adMatch[1].length;
-        if (level > 1) {
-          list.push({ title: adMatch[2].trim(), level });
-        }
+      const trimmed = line.trim();
+      if (trimmed.startsWith('----') || trimmed.startsWith('....') || trimmed.startsWith('```')) {
+        inCodeBlock = !inCodeBlock;
         return;
       }
-      const mdMatch = line.match(/^(#+)\s+(.+)$/);
-      if (mdMatch) {
-        const level = mdMatch[1].length;
-        if (level > 1) {
-          list.push({ title: mdMatch[2].trim(), level });
+      if (inCodeBlock) return;
+
+      if (hasAsciiDocHeadings) {
+        const adMatch = line.match(/^(=+)\s+(.+)$/);
+        if (adMatch) {
+          const level = adMatch[1].length;
+          if (level > 1) {
+            list.push({ title: adMatch[2].trim(), level });
+          }
+        }
+      } else {
+        const mdMatch = line.match(/^(#+)\s+(.+)$/);
+        if (mdMatch) {
+          const level = mdMatch[1].length;
+          if (level > 1) {
+            list.push({ title: mdMatch[2].trim(), level });
+          }
         }
       }
     });

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -7,12 +7,13 @@
   import { naddrEncode } from '@nostr/tools/nip19';
   import { normalizeIdentifier } from '@nostr/tools/nip54';
 
-  import { account, reactionKind, wikiKind, signer } from '$lib/nostr';
+  import { account, reactionKind, wikiKind, gitPatchKind, signer } from '$lib/nostr';
   import { formatDate, getA, getTagOr, next } from '$lib/utils';
   import type { ArticleCard, SearchCard, Card } from '$lib/types';
   import UserLabel from '$components/UserLabel.svelte';
   import ArticleContent from '$components/ArticleContent.svelte';
   import RelayItem from '$components/RelayItem.svelte';
+  import { diffLines } from '$lib/diff';
 
   interface Props {
     card: Card;
@@ -23,6 +24,10 @@
 
   let { card, createChild, replaceSelf, back }: Props = $props();
   let event = $state<NostrEvent | null>(null);
+  let suggestions = $state<NostrEvent[]>([]);
+  let showSuggestionsPanel = $state(false);
+  let selectedSuggestion = $state<NostrEvent | null>(null);
+  let merging = $state(false);
   let nOthers = $state<number | undefined>(undefined);
   let copied = $state(false);
   let likeStatus: 'liked' | 'disliked' | unknown;
@@ -46,9 +51,9 @@
       type: 'editor',
       data: {
         title,
-        summary,
-        content: event?.content,
-        previous: card
+        summary: summary || '',
+        content: event?.content || '',
+        previous: card as ArticleCard
       }
     });
   }
@@ -124,6 +129,30 @@
             if (!event || event.created_at < evt.created_at) {
               event = evt;
               setupLikes();
+            }
+          }
+        }
+      );
+    })();
+
+    (async () => {
+      let relays = await loadRelayList(pubkey);
+      pool.subscribeMany(
+        relays.items
+          .filter((ri) => ri.read)
+          .map((ri) => ri.url)
+          .concat((card as ArticleCard).relayHints || []),
+        [
+          {
+            kinds: [gitPatchKind],
+            '#a': [`${wikiKind}:${pubkey}:${dTag}`]
+          }
+        ],
+        {
+          id: 'suggestions-' + dTag,
+          onevent(evt) {
+            if (!suggestions.some((s) => s.id === evt.id)) {
+              suggestions = [...suggestions, evt].sort((a, b) => b.created_at - a.created_at);
             }
           }
         }
@@ -306,7 +335,7 @@
             {#if event?.pubkey === $account?.pubkey}
               Edit
             {:else}
-              Fork
+              Fork / Suggest Edit
             {/if}
           </a>
           &nbsp;• &nbsp;
@@ -315,9 +344,170 @@
           </a>
           &nbsp;• &nbsp;
           <a class="cursor-pointer underline" onmouseup={seeOthers}>{nOthers || ''} Versions</a>
+          {#if suggestions.length > 0}
+            &nbsp;• &nbsp;
+            <a class="cursor-pointer underline text-emerald-600 hover:text-emerald-700 font-semibold" onclick={() => showSuggestionsPanel = !showSuggestionsPanel}>
+              {suggestions.length} Suggestion{suggestions.length > 1 ? 's' : ''}
+            </a>
+          {/if}
         </div>
       </div>
     </div>
+
+    <!-- Suggestions Panel -->
+    {#if showSuggestionsPanel}
+      <div class="mt-2 mb-4 p-4 border border-emerald-200 rounded-lg bg-emerald-50/30">
+        <div class="flex justify-between items-center mb-3">
+          <h3 class="font-bold text-lg text-emerald-800">Suggestions (Pull Requests)</h3>
+          <button 
+            onclick={() => { showSuggestionsPanel = false; selectedSuggestion = null; }}
+            class="text-xs text-stone-500 hover:text-stone-700 bg-white border border-stone-200 px-2 py-0.5 rounded shadow-sm"
+          >
+            Hide
+          </button>
+        </div>
+
+        {#if !selectedSuggestion}
+          {#if suggestions.length === 0}
+            <p class="text-stone-500 text-sm">No suggestions yet.</p>
+          {:else}
+            <div class="space-y-2">
+              {#each suggestions as sug (sug.id)}
+                <div class="p-3 bg-white border border-stone-200 rounded shadow-sm hover:border-emerald-500 transition-colors flex justify-between items-start">
+                  <div>
+                    <div class="font-semibold text-stone-900 text-sm">
+                      {getTagOr(sug, 'title') || 'Proposed Edit'}
+                    </div>
+                    <div class="text-xs text-stone-500 mt-1">
+                      by <UserLabel pubkey={sug.pubkey} {createChild} /> {formatDate(sug.created_at)}
+                    </div>
+                    {#if getTagOr(sug, 'summary')}
+                      <div class="text-xs text-stone-600 mt-1 bg-stone-50 p-1.5 rounded italic">
+                        "{getTagOr(sug, 'summary')}"
+                      </div>
+                    {/if}
+                  </div>
+                  <button
+                    onclick={() => selectedSuggestion = sug}
+                    class="ml-4 px-2.5 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700 font-semibold"
+                  >
+                    Review Diff
+                  </button>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        {:else}
+          <!-- Reviewing a specific suggestion -->
+          <div class="bg-white border border-emerald-100 rounded p-3 shadow-sm">
+            <div class="flex justify-between items-center mb-3 border-b border-stone-100 pb-1.5">
+              <div>
+                <div class="text-xs text-stone-500">Reviewing suggestion from:</div>
+                <div class="font-medium text-xs flex items-center gap-1">
+                  <UserLabel pubkey={selectedSuggestion.pubkey} {createChild} />
+                  <span class="text-[10px] text-stone-400">({formatDate(selectedSuggestion.created_at)})</span>
+                </div>
+              </div>
+              <button 
+                onclick={() => selectedSuggestion = null}
+                class="text-xs text-indigo-600 hover:text-indigo-850 font-medium"
+              >
+                ← Back
+              </button>
+            </div>
+
+            <!-- Diff Viewer -->
+            <div class="mt-2 border border-stone-200 rounded overflow-hidden font-mono text-xs max-h-72 overflow-y-auto bg-stone-50">
+              {#each diffLines(event?.content || '', selectedSuggestion.content) as line, idx}
+                <div class="flex select-text {line.type === 'added' ? 'bg-emerald-50 text-emerald-900' : ''} {line.type === 'removed' ? 'bg-rose-50 text-rose-900' : ''}">
+                  <div class="w-10 text-right text-stone-400 select-none border-r border-stone-200/50 pr-1.5 mr-1.5 bg-stone-100/50 text-[10px] py-0.5">
+                    {idx + 1}
+                  </div>
+                  <div class="w-4 select-none text-center font-bold" class:text-emerald-600={line.type === 'added'} class:text-rose-600={line.type === 'removed'}>
+                    {#if line.type === 'added'}+{/if}
+                    {#if line.type === 'removed'}-{/if}
+                    {#if line.type === 'unmodified'}&nbsp;{/if}
+                  </div>
+                  <div class="whitespace-pre-wrap py-0.5 break-all flex-1">{line.value}</div>
+                </div>
+              {/each}
+            </div>
+
+            <!-- Merge/Approve Actions -->
+            <div class="mt-3 flex justify-end space-x-2 border-t border-stone-100 pt-2">
+              {#if $account?.pubkey === event?.pubkey}
+                <button
+                  onclick={async () => {
+                    if (!selectedSuggestion || !event) return;
+                    merging = true;
+                    try {
+                      let eventTemplate: EventTemplate = {
+                        kind: wikiKind,
+                        tags: [
+                          ['d', getTagOr(event, 'd')],
+                          ['contributor', selectedSuggestion.pubkey]
+                        ],
+                        content: selectedSuggestion.content.trim(),
+                        created_at: Math.round(Date.now() / 1000)
+                      };
+
+                      const propTitle = getTagOr(selectedSuggestion, 'title') || getTagOr(event, 'title');
+                      if (propTitle && propTitle !== getTagOr(event, 'd')) {
+                        eventTemplate.tags.push(['title', propTitle]);
+                      }
+                      const propSummary = getTagOr(selectedSuggestion, 'summary') || getTagOr(event, 'summary');
+                      if (propSummary) {
+                        eventTemplate.tags.push(['summary', propSummary]);
+                      }
+
+                      let signed = await signer.signEvent(eventTemplate);
+                      let successes: string[] = [];
+                      await Promise.all(
+                        seenOn.map(async (url) => {
+                          try {
+                            const r = await pool.ensureRelay(url);
+                            await r.publish(signed);
+                            successes.push(url);
+                          } catch (err) {
+                            console.warn('Failed publishing merged event to', url, err);
+                          }
+                        })
+                      );
+
+                      if (successes.length) {
+                        event = signed;
+                        suggestions = suggestions.filter((s) => s.id !== selectedSuggestion!.id);
+                        selectedSuggestion = null;
+                        showSuggestionsPanel = false;
+                      }
+                    } catch (err) {
+                      alert('Error merging suggestion: ' + err);
+                    } finally {
+                      merging = false;
+                    }
+                  }}
+                  disabled={merging}
+                  class="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-white rounded font-semibold text-xs disabled:opacity-50"
+                >
+                  {#if merging}Merging...{:else}Accept & Merge{/if}
+                </button>
+              {/if}
+              <button
+                onclick={() => {
+                  if (selectedSuggestion) {
+                    suggestions = suggestions.filter((s) => s.id !== selectedSuggestion!.id);
+                    selectedSuggestion = null;
+                  }
+                }}
+                class="px-3 py-1.5 bg-stone-100 hover:bg-stone-200 text-stone-700 rounded font-semibold text-xs"
+              >
+                Ignore Suggestion
+              </button>
+            </div>
+          </div>
+        {/if}
+      </div>
+    {/if}
 
     <!-- Content -->
     {#if view === 'raw'}

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -751,7 +751,7 @@
 
       <!-- Table of Contents -->
       {#if headings.length > 0}
-        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 w-full max-w-full sm:max-w-md lg:max-w-lg">
+        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 w-full">
           <div class="text-xs font-bold text-stone-700 uppercase tracking-wider mb-2 border-b border-stone-200 pb-1 flex justify-between items-center">
             <span>Table of Contents</span>
           </div>

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -8,7 +8,7 @@
   import { normalizeIdentifier } from '@nostr/tools/nip54';
 
   import { account, reactionKind, wikiKind, gitPatchKind, signer } from '$lib/nostr';
-  import { formatDate, getA, getTagOr, next } from '$lib/utils';
+  import { formatDate, getA, getTagOr, next, unique } from '$lib/utils';
   import type { ArticleCard, SearchCard, Card } from '$lib/types';
   import UserLabel from '$components/UserLabel.svelte';
   import ArticleContent from '$components/ArticleContent.svelte';
@@ -34,6 +34,89 @@
   let canLike = $state<boolean | undefined>();
   let seenOn = $state<string[]>([]);
   let view = $state<'formatted' | 'asciidoc' | 'raw'>('formatted');
+
+  // Wiki features state
+  let activeTab = $state<'article' | 'discussion' | 'history'>('article');
+  let comments = $state<NostrEvent[]>([]);
+  let newCommentText = $state('');
+  let publishingComment = $state(false);
+  let historyEvents = $state<NostrEvent[]>([]);
+  let backlinks = $state<NostrEvent[]>([]);
+
+  interface Heading {
+    title: string;
+    level: number;
+  }
+
+  let headings = $derived.by<Heading[]>(() => {
+    if (!event?.content) return [];
+    const lines = event.content.split(/\r?\n/);
+    const list: Heading[] = [];
+    lines.forEach((line) => {
+      const adMatch = line.match(/^(=+)\s+(.+)$/);
+      if (adMatch) {
+        list.push({ title: adMatch[2].trim(), level: adMatch[1].length });
+        return;
+      }
+      const mdMatch = line.match(/^(#+)\s+(.+)$/);
+      if (mdMatch) {
+        list.push({ title: mdMatch[2].trim(), level: mdMatch[1].length });
+      }
+    });
+    return list;
+  });
+
+  function scrollToHeading(headingTitle: string) {
+    const cardEl = document.getElementById(`wikicard-${card.id}`);
+    if (!cardEl) return;
+    const elements = cardEl.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    for (const el of Array.from(elements)) {
+      if (el.textContent?.trim().toLowerCase() === headingTitle.toLowerCase()) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        break;
+      }
+    }
+  }
+
+  async function publishComment() {
+    if (!newCommentText.trim() || !event) return;
+    publishingComment = true;
+    try {
+      const commentTemplate: EventTemplate = {
+        kind: 1111,
+        tags: [
+          ['a', `${wikiKind}:${pubkey}:${dTag}`, seenOn[0] || ''],
+          ['e', event.id, seenOn[0] || '']
+        ],
+        content: newCommentText.trim(),
+        created_at: Math.round(Date.now() / 1000)
+      };
+
+      const signed = await signer.signEvent(commentTemplate);
+      const relays = unique(
+        (await loadRelayList($account!.pubkey)).items.filter((ri) => ri.write).map((ri) => ri.url),
+        seenOn
+      );
+
+      await Promise.all(
+        relays.map(async (url: string) => {
+          try {
+            const r = await pool.ensureRelay(url);
+            await r.publish(signed);
+          } catch (err) {
+            console.warn('Failed publishing comment to', url, err);
+          }
+        })
+      );
+
+      comments = [...comments, signed].sort((a, b) => a.created_at - b.created_at);
+      newCommentText = '';
+    } catch (err) {
+      alert('Failed to publish comment: ' + err);
+    } finally {
+      publishingComment = false;
+    }
+  }
 
   const articleCard = card as ArticleCard;
   const dTag = articleCard.data[0];
@@ -153,6 +236,81 @@
           onevent(evt) {
             if (!suggestions.some((s) => s.id === evt.id)) {
               suggestions = [...suggestions, evt].sort((a, b) => b.created_at - a.created_at);
+            }
+          }
+        }
+      );
+    })();
+
+    // load comments
+    (async () => {
+      let relays = await loadRelayList(pubkey);
+      pool.subscribeMany(
+        relays.items
+          .filter((ri) => ri.read)
+          .map((ri) => ri.url)
+          .concat((card as ArticleCard).relayHints || []),
+        [
+          {
+            kinds: [1, 1111],
+            '#a': [`${wikiKind}:${pubkey}:${dTag}`]
+          }
+        ],
+        {
+          id: 'comments-' + dTag,
+          onevent(evt) {
+            if (!comments.some((c) => c.id === evt.id)) {
+              comments = [...comments, evt].sort((a, b) => a.created_at - b.created_at);
+            }
+          }
+        }
+      );
+    })();
+
+    // load history revisions
+    (async () => {
+      let relays = await loadRelayList(pubkey);
+      pool.subscribeMany(
+        relays.items
+          .filter((ri) => ri.read)
+          .map((ri) => ri.url)
+          .concat((card as ArticleCard).relayHints || []),
+        [
+          {
+            kinds: [wikiKind],
+            '#d': [dTag]
+          }
+        ],
+        {
+          id: 'history-' + dTag,
+          onevent(evt) {
+            if (!historyEvents.some((h) => h.id === evt.id)) {
+              historyEvents = [...historyEvents, evt].sort((a, b) => b.created_at - a.created_at);
+            }
+          }
+        }
+      );
+    })();
+
+    // load backlinks
+    (async () => {
+      let relays = await loadRelayList(pubkey);
+      pool.subscribeMany(
+        relays.items
+          .filter((ri) => ri.read)
+          .map((ri) => ri.url)
+          .concat((card as ArticleCard).relayHints || []),
+        [
+          {
+            kinds: [wikiKind],
+            '#a': [`${wikiKind}:${pubkey}:${dTag}`]
+          }
+        ],
+        {
+          id: 'backlinks-' + dTag,
+          onevent(evt) {
+            if (!backlinks.some((b) => b.id === evt.id)) {
+              backlinks = [...backlinks, evt];
             }
           }
         }
@@ -509,14 +667,223 @@
       </div>
     {/if}
 
-    <!-- Content -->
-    {#if view === 'raw'}
-      <div class="font-mono whitespace-pre-wrap">{rawEvent}</div>
-    {:else if view === 'asciidoc'}
-      <div class="prose whitespace-pre-wrap">{event.content}</div>
-    {:else if view === 'formatted'}
-      <div class="prose prose-p:my-0 prose-li:my-0">
-        <ArticleContent {event} {createChild} />
+    <!-- Tabs Header -->
+    <div class="mt-4 border-b border-stone-250 flex items-center space-x-4">
+      <button
+        onclick={() => activeTab = 'article'}
+        class="pb-2 text-sm font-bold border-b-2 transition-colors focus:outline-none"
+        class:border-indigo-600={activeTab === 'article'}
+        class:text-indigo-600={activeTab === 'article'}
+        class:border-transparent={activeTab !== 'article'}
+        class:text-stone-500={activeTab !== 'article'}
+      >
+        Article
+      </button>
+      <button
+        onclick={() => activeTab = 'discussion'}
+        class="pb-2 text-sm font-bold border-b-2 transition-colors focus:outline-none flex items-center gap-1.5"
+        class:border-indigo-600={activeTab === 'discussion'}
+        class:text-indigo-600={activeTab === 'discussion'}
+        class:border-transparent={activeTab !== 'discussion'}
+        class:text-stone-500={activeTab !== 'discussion'}
+      >
+        Discussion
+        {#if comments.length > 0}
+          <span class="bg-stone-200 text-stone-700 px-1.5 py-0.5 rounded-full text-[10px]">
+            {comments.length}
+          </span>
+        {/if}
+      </button>
+      <button
+        onclick={() => activeTab = 'history'}
+        class="pb-2 text-sm font-bold border-b-2 transition-colors focus:outline-none"
+        class:border-indigo-600={activeTab === 'history'}
+        class:text-indigo-600={activeTab === 'history'}
+        class:border-transparent={activeTab !== 'history'}
+        class:text-stone-500={activeTab !== 'history'}
+      >
+        History
+      </button>
+    </div>
+
+    <!-- Tab Contents -->
+    {#if activeTab === 'article'}
+      <!-- Info / Metadata Box (Wiki Sidebar) -->
+      <div class="mt-4 p-3 bg-stone-50 border border-stone-200 rounded shadow-sm flex flex-col md:flex-row justify-between text-xs text-stone-600 gap-2 mb-4">
+        <div>
+          <span class="font-semibold text-stone-700">Page size:</span>
+          {event.content.length} characters ({Math.round(event.content.length / 10.24) / 100} KB)
+        </div>
+        <div>
+          <span class="font-semibold text-stone-700">Revisions:</span>
+          {historyEvents.filter(h => h.pubkey === event?.pubkey).length || 1}
+        </div>
+        <div>
+          <span class="font-semibold text-stone-700">Contributors:</span>
+          {unique(historyEvents.map(h => h.pubkey)).length || 1}
+        </div>
+        <div>
+          <span class="font-semibold text-stone-700">First published:</span>
+          {#if historyEvents.length > 0}
+            {formatDate(historyEvents[historyEvents.length - 1].created_at)}
+          {:else}
+            {formatDate(event.created_at)}
+          {/if}
+        </div>
+      </div>
+
+      <!-- Table of Contents -->
+      {#if headings.length > 0}
+        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 max-w-sm">
+          <div class="text-xs font-bold text-stone-700 uppercase tracking-wider mb-2 border-b border-stone-200 pb-1 flex justify-between items-center">
+            <span>Table of Contents</span>
+          </div>
+          <ul class="space-y-1.5 text-sm">
+            {#each headings as heading}
+              <li style:padding-left={`${(heading.level - 1) * 12}px`}>
+                <a
+                  href="javascript:void(0)"
+                  onclick={() => scrollToHeading(heading.title)}
+                  class="text-indigo-600 hover:text-indigo-850 hover:underline inline-block break-all"
+                >
+                  {heading.title}
+                </a>
+              </li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+
+      <!-- Main Article Content -->
+      {#if view === 'raw'}
+        <div class="font-mono whitespace-pre-wrap text-sm border border-stone-200 p-3 bg-stone-50 rounded">{rawEvent}</div>
+      {:else if view === 'asciidoc'}
+        <div class="prose whitespace-pre-wrap text-sm border border-stone-200 p-3 bg-stone-50 rounded">{event.content}</div>
+      {:else if view === 'formatted'}
+        <div class="prose prose-p:my-0 prose-li:my-0">
+          <ArticleContent {event} {createChild} />
+        </div>
+      {/if}
+
+      <!-- Backlinks section ("What links here") -->
+      <div class="mt-8 border-t border-stone-250 pt-4">
+        <details class="group">
+          <summary class="cursor-pointer text-xs font-semibold text-stone-500 hover:text-stone-850 focus:outline-none flex items-center select-none">
+            <svg class="w-3.5 h-3.5 mr-1 transform group-open:rotate-90 transition-transform stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" /></svg>
+            What links here ({backlinks.length})
+          </summary>
+          {#if backlinks.length === 0}
+            <div class="mt-2 text-xs text-stone-400 italic pl-5">No other articles link to this article yet.</div>
+          {:else}
+            <ul class="mt-2 text-xs space-y-1 pl-5 list-disc text-indigo-600">
+              {#each backlinks as link (link.id)}
+                <li>
+                  <a
+                    href="javascript:void(0)"
+                    onclick={() => {
+                      createChild({
+                        id: next(),
+                        type: 'article',
+                        data: [getTagOr(link, 'd'), link.pubkey],
+                        actualEvent: link
+                      } as ArticleCard);
+                    }}
+                    class="hover:underline"
+                  >
+                    {getTagOr(link, 'title') || getTagOr(link, 'd')}
+                  </a>
+                  <span class="text-stone-400">by <UserLabel pubkey={link.pubkey} {createChild} /></span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </details>
+      </div>
+
+    {:else if activeTab === 'discussion'}
+      <!-- Comments / Discussion -->
+      <div class="mt-4 space-y-3">
+        {#if comments.length === 0}
+          <div class="text-center py-6 text-stone-400 text-sm italic">
+            No discussion on this article yet. Be the first to start the talk page!
+          </div>
+        {:else}
+          {#each comments as comm (comm.id)}
+            <div class="p-3 bg-stone-50 border border-stone-200 rounded shadow-sm">
+              <div class="flex justify-between items-center border-b border-stone-200/50 pb-1 mb-2 text-xs">
+                <span class="font-semibold text-stone-700">
+                  <UserLabel pubkey={comm.pubkey} {createChild} />
+                </span>
+                <span class="text-stone-400">
+                  {formatDate(comm.created_at)}
+                </span>
+              </div>
+              <div class="text-stone-800 text-sm whitespace-pre-wrap select-text">{comm.content}</div>
+            </div>
+          {/each}
+        {/if}
+
+        <!-- Post a Comment -->
+        {#if $account}
+          <div class="mt-6 border-t border-stone-200 pt-4">
+            <h4 class="text-sm font-semibold text-stone-700 mb-2">Add to the discussion:</h4>
+            <textarea
+              bind:value={newCommentText}
+              placeholder="Provide constructive feedback, propose edits, or ask questions about the article..."
+              class="w-full h-24 p-2 text-sm border border-stone-300 rounded focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+              disabled={publishingComment}
+            ></textarea>
+            <div class="mt-2 flex justify-end">
+              <button
+                onclick={publishComment}
+                disabled={publishingComment || !newCommentText.trim()}
+                class="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-xs rounded shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+              >
+                {#if publishingComment}Publishing...{:else}Post Comment{/if}
+              </button>
+            </div>
+          </div>
+        {:else}
+          <div class="mt-6 border-t border-stone-200 pt-4 text-center text-xs text-stone-500 italic">
+            Please log in with a Nostr extension to participate in the discussion.
+          </div>
+        {/if}
+      </div>
+
+    {:else if activeTab === 'history'}
+      <!-- History Revisions -->
+      <div class="mt-4 space-y-2">
+        <h4 class="text-sm font-semibold text-stone-700 mb-3">Revision History:</h4>
+        {#if historyEvents.length === 0}
+          <div class="text-xs text-stone-400 italic">Loading revision history...</div>
+        {:else}
+          <div class="border border-stone-200 rounded divide-y divide-stone-200">
+            {#each historyEvents as rev}
+              <div class="p-3 bg-white hover:bg-stone-50 flex justify-between items-center text-xs">
+                <div>
+                  <span class="font-mono text-[10px] bg-stone-100 text-stone-600 px-1.5 py-0.5 rounded mr-2">
+                    {rev.id.substring(0, 8)}
+                  </span>
+                  <span class="text-stone-500 font-semibold">{formatDate(rev.created_at)}</span>
+                  <span class="text-stone-400 mx-1.5">•</span>
+                  <span>by <UserLabel pubkey={rev.pubkey} {createChild} /></span>
+                  {#if getTagOr(rev, 'summary')}
+                    <span class="text-stone-400 block mt-1 italic">"{getTagOr(rev, 'summary')}"</span>
+                  {/if}
+                </div>
+                <button
+                  onclick={() => {
+                    event = rev;
+                    activeTab = 'article';
+                  }}
+                  class="px-2 py-0.5 border border-stone-300 rounded bg-stone-50 hover:bg-stone-100 font-semibold"
+                >
+                  View Revision
+                </button>
+              </div>
+            {/each}
+          </div>
+        {/if}
       </div>
     {/if}
 

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -66,6 +66,23 @@
     return list;
   });
 
+  let contributors = $derived.by<string[]>(() => {
+    const list: string[] = [pubkey];
+    if (event?.tags) {
+      event.tags.forEach(([tag, val]) => {
+        if (tag === 'contributor' && val && !list.includes(val)) {
+          list.push(val);
+        }
+      });
+    }
+    historyEvents.forEach((rev) => {
+      if (rev.pubkey && !list.includes(rev.pubkey)) {
+        list.push(rev.pubkey);
+      }
+    });
+    return list;
+  });
+
   function scrollToHeading(headingTitle: string) {
     const cardEl = document.getElementById(`wikicard-${card.id}`);
     if (!cardEl) return;
@@ -798,6 +815,18 @@
             </ul>
           {/if}
         </details>
+      </div>
+
+      <!-- Contributors -->
+      <div class="mt-6 border-t border-stone-250 pt-4 text-xs text-stone-500">
+        <span class="font-semibold text-stone-700">Contributors:</span>
+        <div class="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+          {#each contributors as cPubkey}
+            <div class="inline-flex items-center">
+              <UserLabel pubkey={cPubkey} {createChild} />
+            </div>
+          {/each}
+        </div>
       </div>
 
     {:else if activeTab === 'discussion'}

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -55,16 +55,24 @@
     lines.forEach((line) => {
       const adMatch = line.match(/^(=+)\s+(.+)$/);
       if (adMatch) {
-        list.push({ title: adMatch[2].trim(), level: adMatch[1].length });
+        const level = adMatch[1].length;
+        if (level > 1) {
+          list.push({ title: adMatch[2].trim(), level });
+        }
         return;
       }
       const mdMatch = line.match(/^(#+)\s+(.+)$/);
       if (mdMatch) {
-        list.push({ title: mdMatch[2].trim(), level: mdMatch[1].length });
+        const level = mdMatch[1].length;
+        if (level > 1) {
+          list.push({ title: mdMatch[2].trim(), level });
+        }
       }
     });
     return list;
   });
+
+  let minHeadingLevel = $derived(headings.length > 0 ? Math.min(...headings.map(h => h.level)) : 2);
 
   let contributors = $derived.by<string[]>(() => {
     const list: string[] = [pubkey];
@@ -757,7 +765,7 @@
           </div>
           <ul class="space-y-1.5 text-sm">
             {#each headings as heading}
-              <li style:padding-left={`${(heading.level - 1) * 12}px`}>
+              <li style:padding-left={`${(heading.level - minHeadingLevel) * 12}px`}>
                 <a
                   href="javascript:void(0)"
                   onclick={() => scrollToHeading(heading.title)}

--- a/src/cards/Editor.svelte
+++ b/src/cards/Editor.svelte
@@ -180,7 +180,7 @@
   }
 
   async function suggest() {
-    if (!isSomeoneElsesArticle || !data.previous) return;
+    if (!isSomeoneElsesArticle || !data.previous || data.previous.type !== 'article') return;
     const originalPubkey = data.previous.data[1];
     const originalDTag = data.previous.data[0];
 

--- a/src/cards/Editor.svelte
+++ b/src/cards/Editor.svelte
@@ -4,7 +4,7 @@
 
   import WikilinkComponent from '$components/WikilinkComponent.svelte';
   import { DEFAULT_WIKI_RELAYS } from '$lib/defaults';
-  import { wikiKind, account, signer } from '$lib/nostr';
+  import { wikiKind, gitPatchKind, account, signer } from '$lib/nostr';
   import type { ArticleCard, Card, EditorCard, EditorData } from '$lib/types.ts';
   import {
     getTagOr,
@@ -31,6 +31,12 @@
   let targets: { url: string; status: 'pending' | 'success' | 'failure'; message?: string }[] =
     $state([]);
   let previewing = $state(false);
+
+  let isSomeoneElsesArticle = $derived(
+    data.previous &&
+    data.previous.type === 'article' &&
+    data.previous.data[1] !== $account?.pubkey
+  );
 
   async function publish() {
     targets = unique(
@@ -87,11 +93,74 @@
       return;
     }
   }
+
+  async function suggest() {
+    if (!isSomeoneElsesArticle || !data.previous) return;
+    const originalPubkey = data.previous.data[1];
+    const originalDTag = data.previous.data[0];
+
+    targets = unique(
+      (await loadRelayList($account!.pubkey)).items.filter((ri) => ri.write).map((ri) => ri.url),
+      DEFAULT_WIKI_RELAYS
+    ).map((url) => ({ url, status: 'pending' }));
+    error = undefined;
+
+    data.title = data.title.trim();
+
+    let eventTemplate: EventTemplate = {
+      kind: gitPatchKind,
+      tags: [
+        ['a', `${wikiKind}:${originalPubkey}:${originalDTag}`, (data.previous as any).relayHints?.[0] || ''],
+        ['p', originalPubkey]
+      ],
+      content: data.content.trim(),
+      created_at: Math.round(Date.now() / 1000)
+    };
+    if (data.title) eventTemplate.tags.push(['title', data.title]);
+    if (data.summary) eventTemplate.tags.push(['summary', data.summary]);
+
+    try {
+      let event = await signer.signEvent(eventTemplate);
+      let successes: string[] = [];
+
+      await Promise.all(
+        targets.map(async (target, i) => {
+          try {
+            const r = await pool.ensureRelay(target.url);
+            await r.publish(event);
+            target.status = 'success';
+            successes.push(target.url);
+          } catch (err) {
+            target.status = 'failure';
+            target.message = String(err);
+          }
+          targets[i] = target;
+          targets = targets;
+        })
+      );
+
+      if (successes.length) {
+        setTimeout(() => {
+          if (data.previous) {
+            replaceSelf(data.previous);
+          }
+        }, 1400);
+      }
+    } catch (err) {
+      error = String(err);
+      targets = [];
+      return;
+    }
+  }
 </script>
 
 <div class="my-4 font-bold text-4xl">
   {#if editorCard.data.content}
-    Editing an article
+    {#if isSomeoneElsesArticle}
+      Suggesting changes to article
+    {:else}
+      Editing an article
+    {/if}
   {:else}
     Creating an article
   {/if}
@@ -103,7 +172,8 @@
       <input
         placeholder="example: Greek alphabet"
         bind:value={data.title}
-        class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md ml-2"
+        disabled={isSomeoneElsesArticle}
+        class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md ml-2 disabled:bg-gray-100 disabled:text-gray-500"
       /></label
     >
   </div>
@@ -168,12 +238,27 @@
       {error}
     </div>
   {/if}
-  <div class="mt-2 flex justify-between">
-    <button
-      onclick={publish}
-      class="cursor-pointer inline-flex items-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-      >Save</button
-    >
+  <div class="mt-2 flex justify-between items-center">
+    <div class="flex space-x-2">
+      {#if isSomeoneElsesArticle}
+        <button
+          onclick={suggest}
+          class="cursor-pointer inline-flex items-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-emerald-600 hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500"
+          >Submit Change</button
+        >
+        <button
+          onclick={publish}
+          class="cursor-pointer inline-flex items-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >Publish Fork</button
+        >
+      {:else}
+        <button
+          onclick={publish}
+          class="cursor-pointer inline-flex items-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >Save</button
+        >
+      {/if}
+    </div>
     <button
       onclick={() => {
         previewing = !previewing;

--- a/src/cards/Editor.svelte
+++ b/src/cards/Editor.svelte
@@ -16,6 +16,7 @@
   import { pool } from '@nostr/gadgets/global';
   import { loadRelayList } from '@nostr/gadgets/lists';
   import { normalizeIdentifier } from '@nostr/tools/nip54';
+  import debounce from 'debounce';
 
   interface Props {
     replaceSelf: (card: Card) => void;
@@ -31,6 +32,90 @@
   let targets: { url: string; status: 'pending' | 'success' | 'failure'; message?: string }[] =
     $state([]);
   let previewing = $state(false);
+
+  // Article lookup state
+  let textareaEl = $state<HTMLTextAreaElement | null>(null);
+  let showLookup = $state(false);
+  let lookupQuery = $state('');
+  let lookupResults = $state<any[]>([]);
+  let lookupSearching = $state(false);
+  let lookupSub = $state<any>(null);
+
+  async function performLookupSearch() {
+    if (lookupSub) {
+      lookupSub.close();
+      lookupSub = null;
+    }
+    lookupResults = [];
+    if (!lookupQuery.trim()) {
+      lookupSearching = false;
+      return;
+    }
+    lookupSearching = true;
+
+    const searchRelays = unique(
+      (await loadRelayList($account?.pubkey || '')).items.filter((ri) => ri.read).map((ri) => ri.url),
+      DEFAULT_WIKI_RELAYS
+    );
+
+    lookupSub = pool.subscribeMany(
+      searchRelays,
+      [
+        {
+          kinds: [wikiKind],
+          limit: 50
+        }
+      ],
+      {
+        onevent(evt) {
+          const title = getTagOr(evt, 'title') || getTagOr(evt, 'd');
+          if (
+            title.toLowerCase().includes(lookupQuery.toLowerCase()) &&
+            !lookupResults.some((r) => r.id === evt.id)
+          ) {
+            lookupResults = [...lookupResults, evt].slice(0, 10);
+          }
+        },
+        oneose() {
+          lookupSearching = false;
+        }
+      }
+    );
+  }
+
+  const debouncedLookup = debounce(performLookupSearch, 400);
+
+  $effect(() => {
+    if (lookupQuery !== undefined) {
+      debouncedLookup();
+    }
+  });
+
+  function insertLink(targetTitle: string) {
+    if (!textareaEl) return;
+    const start = textareaEl.selectionStart;
+    const end = textareaEl.selectionEnd;
+    const text = data.content;
+    const selection = text.substring(start, end);
+
+    let linkText = '';
+    if (selection) {
+      linkText = `[[${targetTitle}|${selection}]]`;
+    } else {
+      linkText = `[[${targetTitle}]]`;
+    }
+
+    data.content = text.substring(0, start) + linkText + text.substring(end);
+    showLookup = false;
+    lookupQuery = '';
+    lookupResults = [];
+
+    setTimeout(() => {
+      textareaEl?.focus();
+      const newCursorPos = start + linkText.length;
+      textareaEl?.setSelectionRange(newCursorPos, newCursorPos);
+    }, 50);
+  }
 
   let isSomeoneElsesArticle = $derived(
     data.previous &&
@@ -180,7 +265,62 @@
   <div class="mt-2">
     <!-- svelte-ignore a11y_label_has_associated_control -->
     <label>
-      Article
+      <div class="flex justify-between items-center mt-1 mb-1">
+        <span class="font-semibold text-stone-700">Article</span>
+        {#if !previewing}
+          <button
+            type="button"
+            onclick={() => showLookup = !showLookup}
+            class="text-xs text-indigo-600 hover:text-indigo-800 font-semibold focus:outline-none flex items-center bg-indigo-50 px-2.5 py-1 rounded border border-indigo-150 transition-colors"
+          >
+            <svg class="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" /></svg>
+            Insert Link
+          </button>
+        {/if}
+      </div>
+
+      {#if showLookup && !previewing}
+        <div class="my-2 p-3 bg-stone-50 border border-stone-200 rounded-lg shadow-inner">
+          <div class="text-xs font-semibold text-stone-700 mb-1.5 flex justify-between items-center">
+            <span>Search articles to reference:</span>
+            <button onclick={() => { showLookup = false; lookupQuery = ''; }} class="text-[10px] text-stone-400 hover:text-stone-600">Cancel</button>
+          </div>
+          <div class="flex gap-2">
+            <input
+              bind:value={lookupQuery}
+              placeholder="Type title to lookup..."
+              class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-stone-300 rounded-md p-1.5"
+            />
+          </div>
+          {#if lookupSearching}
+            <div class="text-[10px] text-stone-400 mt-2 italic">Searching relays...</div>
+          {/if}
+          {#if lookupResults.length > 0}
+            <div class="mt-2 border border-stone-200 rounded divide-y divide-stone-150 max-h-40 overflow-y-auto bg-white shadow-sm">
+              {#each lookupResults as res (res.id)}
+                <button
+                  type="button"
+                  onclick={() => insertLink(getTagOr(res, 'title') || getTagOr(res, 'd'))}
+                  class="w-full text-left p-2 hover:bg-stone-50 text-xs font-medium text-stone-700 flex justify-between items-center focus:outline-none transition-colors border-none"
+                >
+                  <span class="font-semibold text-indigo-700">{getTagOr(res, 'title') || getTagOr(res, 'd')}</span>
+                  <span class="text-[9px] text-stone-400">by {res.pubkey.substring(0, 8)}</span>
+                </button>
+              {/each}
+            </div>
+          {:else if lookupQuery && !lookupSearching}
+            <div class="text-[10px] text-stone-400 mt-2 italic">No matching pages found on relays. You can still insert this as a new wikilink:</div>
+            <button
+              type="button"
+              onclick={() => insertLink(lookupQuery)}
+              class="mt-2 px-3 py-1 bg-stone-200 hover:bg-stone-300 rounded text-[10px] font-semibold text-stone-700 transition-colors"
+            >
+              Insert "[[{lookupQuery}]]"
+            </button>
+          {/if}
+        </div>
+      {/if}
+
       {#if previewing}
         <div class="prose prose-p:my-0 prose-li:my-0">
           <SvelteAsciidoc
@@ -190,6 +330,7 @@
         </div>
       {:else}
         <textarea
+          bind:this={textareaEl}
           placeholder="The **Greek alphabet** has been used to write the [[Greek language]] sincie the late 9th or early 8th century BC. The Greek alphabet is the ancestor of the [[Latin]] and [[Cyrillic]] scripts."
           bind:value={data.content}
           class="h-64 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md"

--- a/src/cards/New.svelte
+++ b/src/cards/New.svelte
@@ -10,6 +10,7 @@
 
   let { replaceNewCard }: Props = $props();
   let query = $state('');
+  let newTitle = $state('');
 
   function search(ev: SubmitEvent) {
     ev.preventDefault();
@@ -25,19 +26,57 @@
       query = '';
     }
   }
+
+  function createArticle(ev: SubmitEvent) {
+    ev.preventDefault();
+
+    if (newTitle) {
+      replaceNewCard({
+        id: next(),
+        type: 'editor',
+        data: {
+          title: newTitle,
+          summary: '',
+          content: ''
+        }
+      } as any);
+      newTitle = '';
+    }
+  }
 </script>
 
-<form onsubmit={search} class="mt- flex rounded-md shadow-sm">
-  <div class="relative flex items-stretch flex-grow focus-within:z-10">
-    <input
-      bind:value={query}
-      class="focus:ring-indigo-500 focus:border-indigo-500 block w-full rounded-none rounded-l-md sm:text-sm border-gray-300"
-      placeholder="article name or search term"
-    />
+<div>
+  <div class="text-sm font-semibold text-gray-700 mb-2">Search for an article:</div>
+  <form onsubmit={search} class="flex rounded-md shadow-sm mb-6">
+    <div class="relative flex items-stretch flex-grow focus-within:z-10">
+      <input
+        bind:value={query}
+        class="focus:ring-indigo-500 focus:border-indigo-500 block w-full rounded-none rounded-l-md sm:text-sm border-gray-300"
+        placeholder="article name or search term"
+      />
+    </div>
+    <button
+      type="submit"
+      class="-ml-px inline-flex items-center space-x-2 px-3 py-2 border border-gray-300 text-sm font-medium rounded-r-md bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 text-white"
+      >Go</button
+    >
+  </form>
+
+  <div class="border-t border-stone-200 pt-6">
+    <div class="text-sm font-semibold text-gray-700 mb-2">Or, create a new article:</div>
+    <form onsubmit={createArticle} class="flex rounded-md shadow-sm">
+      <div class="relative flex items-stretch flex-grow focus-within:z-10">
+        <input
+          bind:value={newTitle}
+          class="focus:ring-indigo-500 focus:border-indigo-500 block w-full rounded-none rounded-l-md sm:text-sm border-gray-300"
+          placeholder="e.g., Quantum physics"
+        />
+      </div>
+      <button
+        type="submit"
+        class="-ml-px inline-flex items-center space-x-2 px-3 py-2 border border-gray-300 text-sm font-medium rounded-r-md bg-emerald-600 hover:bg-emerald-700 focus:outline-none focus:ring-1 focus:ring-emerald-500 focus:border-emerald-500 text-white"
+        >Create</button
+      >
+    </form>
   </div>
-  <button
-    type="submit"
-    class="-ml-px inline-flex items-center space-x-2 px-3 py-2 border border-gray-300 text-sm font-medium rounded-r-md bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 text-white"
-    >Go</button
-  >
-</form>
+</div>

--- a/src/cards/Search.svelte
+++ b/src/cards/Search.svelte
@@ -34,6 +34,8 @@
   let uwrcancel: () => void;
   let search: SubCloser;
   let subs: SubCloser[] = [];
+  let redirectTimeout: ReturnType<typeof setTimeout> | undefined;
+  let redirected = false;
 
   onMount(() => {
     query = searchCard.data;
@@ -58,6 +60,10 @@
     if (uwrcancel) uwrcancel();
     subs.forEach((sub) => sub.close());
     if (search) search.close();
+    if (redirectTimeout) {
+      clearTimeout(redirectTimeout);
+      redirectTimeout = undefined;
+    }
   }
 
   async function performSearch() {
@@ -66,6 +72,7 @@
     tried = false;
     eosed = 0;
     results = [];
+    redirected = false;
 
     setTimeout(() => {
       tried = true;
@@ -133,10 +140,31 @@
             if (searchCard.preferredAuthors.includes(evt.pubkey)) {
               // we found an exact match that fits the list of preferred authors
               // jump straight into it
+              redirected = true;
+              if (redirectTimeout) clearTimeout(redirectTimeout);
               openArticle(evt, undefined, true);
             }
 
-            if (addUniqueTaggedReplaceable(results, evt)) update();
+            if (addUniqueTaggedReplaceable(results, evt)) {
+              update();
+
+              // If we have not redirected yet, check if this is an exact match and schedule a fallback redirect
+              if (!redirected && getTagOr(evt, 'd') === normalizeIdentifier(query)) {
+                if (!redirectTimeout) {
+                  redirectTimeout = setTimeout(() => {
+                    if (redirected) return;
+                    // Find the best exact match from results (sorted by WoT)
+                    const exactMatches = results.filter(
+                      (r) => getTagOr(r, 'd') === normalizeIdentifier(query)
+                    );
+                    if (exactMatches.length > 0) {
+                      redirected = true;
+                      openArticle(exactMatches[0], undefined, true);
+                    }
+                  }, 800);
+                }
+              }
+            }
           },
           oneose,
           receivedEvent
@@ -252,7 +280,7 @@
     </p>
     <button
       on:click={() => {
-        replaceSelf({ id: next(), type: 'editor', data: { title: query, previous: card } });
+        replaceSelf({ id: next(), type: 'editor', data: { title: query, summary: '', content: '', previous: card } });
       }}
       class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
     >

--- a/src/cards/Welcome.svelte
+++ b/src/cards/Welcome.svelte
@@ -20,6 +20,7 @@
   import RelayItem from '$components/RelayItem.svelte';
   import { DEFAULT_WIKI_RELAYS } from '$lib/defaults';
   import { pool } from '@nostr/gadgets/global';
+  import New from './New.svelte';
 
   interface Props {
     createChild: (card: Card) => void;
@@ -63,6 +64,10 @@
       actualEvent: result,
       relayHints: seenCache[result.id] || []
     } as ArticleCard);
+  }
+
+  function replaceNewCard(newCard: Card) {
+    createChild(newCard);
   }
 
   function restart() {
@@ -173,6 +178,10 @@
       >Login</button
     >
   {/if}
+</div>
+
+<div class="my-6 p-4 border border-stone-200 rounded-lg bg-stone-50/50">
+  <New {replaceNewCard} />
 </div>
 
 <div class="mb-2 font-bold text-4xl">

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -16,9 +16,11 @@
 
   interface Props {
     card: Card;
+    collapsed?: boolean;
+    onToggleCollapse?: () => void;
   }
 
-  let { card }: Props = $props();
+  let { card, collapsed = false, onToggleCollapse }: Props = $props();
 
   function close() {
     if (card.type === 'editor' && card.data.previous) replaceSelf(card.data.previous);
@@ -110,7 +112,6 @@
   }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
 <div
   id={`wikicard-${card.id}`}
   class="
@@ -118,12 +119,15 @@
   overflow-x-hidden
   mx-2 mt-2
   w-[calc(100vw_-_24px)] min-w-[calc(100vw_-_24px)] max-w-[calc(100vw_-_24px)]
-  {card.type === 'article' || card.type === 'editor'
-    ? 'sm:min-w-[500px] sm:max-w-[500px] lg:min-w-[48rem] lg:max-w-[48rem] xl:min-w-[56rem] xl:max-w-[56rem]' 
-    : 'sm:min-w-[395px] sm:max-w-[395px] lg:min-w-[32rem] lg:max-w-[32rem]'}
+  {collapsed 
+    ? 'sm:min-w-[64px] sm:max-w-[64px] sm:overflow-hidden' 
+    : card.type === 'article' || card.type === 'editor'
+      ? 'sm:min-w-[500px] sm:max-w-[500px] lg:min-w-[48rem] lg:max-w-[48rem] xl:min-w-[56rem] xl:max-w-[56rem]' 
+      : 'sm:min-w-[395px] sm:max-w-[395px] lg:min-w-[32rem] lg:max-w-[32rem]'}
   rounded-lg border-8 bg-white
   h-[calc(100vh_-_32px)]
-  p-4
+  {collapsed ? 'sm:p-2 p-4' : 'p-4'}
+  transition-all duration-300
   scrollbar-thin scrollbar-thumb-stone-300 scrollbar-track-stone-100 hover:scrollbar-thumb-stone-400"
   ondblclick={scrollIntoViewIfNecessary}
   style:border-color={card.type === 'article'
@@ -132,50 +136,87 @@
       ? hashbow(card.data, 88)
       : '#e5e7eb'}
 >
-  {#if card.type !== 'welcome' && card.type !== 'new'}
-    <div class="flex" class:justify-between={card.back} class:justify-end={!card.back}>
-      {#if card.back}
-        <button aria-label="back" onclick={back}>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="w-6 h-6 stroke-stone-500"
-            viewBox="0 0 219.151 219.151"
-          >
-            <path
-              d="M94.861,156.507c2.929,2.928,7.678,2.927,10.606,0c2.93-2.93,2.93-7.678-0.001-10.608l-28.82-28.819l83.457-0.008 c4.142-0.001,7.499-3.358,7.499-7.502c-0.001-4.142-3.358-7.498-7.5-7.498l-83.46,0.008l28.827-28.825 c2.929-2.929,2.929-7.679,0-10.607c-1.465-1.464-3.384-2.197-5.304-2.197c-1.919,0-3.838,0.733-5.303,2.196l-41.629,41.628 c-1.407,1.406-2.197,3.313-2.197,5.303c0.001,1.99,0.791,3.896,2.198,5.305L94.861,156.507z"
-            ></path>
+  {#if collapsed}
+    <!-- Collapsed vertical view on desktop -->
+    <div class="hidden sm:flex flex-col items-center justify-start h-full pt-2 space-y-8 select-none">
+      <button 
+        onclick={onToggleCollapse}
+        class="p-1.5 rounded-md hover:bg-stone-100 text-stone-600 transition-colors"
+        title="Expand welcome column"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 4.5l7.5 7.5-7.5 7.5M4.5 4.5l7.5 7.5-7.5 7.5" />
+        </svg>
+      </button>
+      <div class="text-stone-400 font-bold tracking-widest text-xs uppercase whitespace-nowrap rotate-180" style="writing-mode: vertical-lr;">
+        Welcome & Search
+      </div>
+    </div>
+    <!-- Mobile view fallback -->
+    <div class="sm:hidden flex justify-between items-center mb-4">
+      <div class="font-bold text-lg">Welcome</div>
+      <button onclick={onToggleCollapse} class="p-1 text-stone-600 hover:bg-stone-100 rounded text-sm">Expand</button>
+    </div>
+  {:else}
+    {#if card.type === 'welcome' && onToggleCollapse}
+      <div class="hidden sm:flex justify-end mb-2">
+        <button 
+          onclick={onToggleCollapse}
+          class="p-1 rounded-md hover:bg-stone-100 text-stone-500 transition-colors"
+          title="Collapse welcome column"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M18.75 19.5l-7.5-7.5 7.5-7.5M12 19.5l-7.5-7.5 7.5-7.5" />
           </svg>
         </button>
-      {/if}
-      <button aria-label="close" onclick={close}>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          class="w-6 h-6 stroke-stone-800"
-          viewBox="0 0 24 24"
-          stroke-width="1.5"
-          ><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg
-        >
-      </button>
-    </div>
-  {/if}
-  <article class="font-sans mx-auto p-2 lg:max-w-4xl">
-    {#if card.type === 'article'}
-      <Article {createChild} {replaceSelf} {back} {card} />
-    {:else if card.type === 'new'}
-      <New {replaceNewCard} />
-    {:else if card.type === 'find'}
-      <Search {createChild} {replaceSelf} {card} />
-    {:else if card.type === 'welcome'}
-      <Welcome {createChild} />
-    {:else if card.type === 'relay'}
-      <Relay {createChild} {replaceSelf} {card} />
-    {:else if card.type === 'user'}
-      <User {createChild} {card} />
-    {:else if card.type === 'settings'}
-      <Settings />
-    {:else if card.type === 'editor'}
-      <Editor {replaceSelf} {card} />
+      </div>
     {/if}
-  </article>
+
+    {#if card.type !== 'welcome' && card.type !== 'new'}
+      <div class="flex" class:justify-between={card.back} class:justify-end={!card.back}>
+        {#if card.back}
+          <button aria-label="back" onclick={back}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="w-6 h-6 stroke-stone-500"
+              viewBox="0 0 219.151 219.151"
+            >
+              <path
+                d="M94.861,156.507c2.929,2.928,7.678,2.927,10.606,0c2.93-2.93,2.93-7.678-0.001-10.608l-28.82-28.819l83.457-0.008 c4.142-0.001,7.499-3.358,7.499-7.502c-0.001-4.142-3.358-7.498-7.5-7.498l-83.46,0.008l28.827-28.825 c2.929-2.929,2.929-7.679,0-10.607c-1.465-1.464-3.384-2.197-5.304-2.197c-1.919,0-3.838,0.733-5.303,2.196l-41.629,41.628 c-1.407,1.406-2.197,3.313-2.197,5.303c0.001,1.99,0.791,3.896,2.198,5.305L94.861,156.507z"
+              ></path>
+            </svg>
+          </button>
+        {/if}
+        <button aria-label="close" onclick={close}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            class="w-6 h-6 stroke-stone-800"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            ><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg
+          >
+        </button>
+      </div>
+    {/if}
+    <article class="font-sans mx-auto p-2 lg:max-w-4xl">
+      {#if card.type === 'article'}
+        <Article {createChild} {replaceSelf} {back} {card} />
+      {:else if card.type === 'new'}
+        <New {replaceNewCard} />
+      {:else if card.type === 'find'}
+        <Search {createChild} {replaceSelf} {card} />
+      {:else if card.type === 'welcome'}
+        <Welcome {createChild} />
+      {:else if card.type === 'relay'}
+        <Relay {createChild} {replaceSelf} {card} />
+      {:else if card.type === 'user'}
+        <User {createChild} {card} />
+      {:else if card.type === 'settings'}
+        <Settings />
+      {:else if card.type === 'editor'}
+        <Editor {replaceSelf} {card} />
+      {/if}
+    </article>
+  {/if}
 </div>

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -117,7 +117,7 @@
   overflow-y-auto
   overflow-x-hidden
   mx-2 mt-2
-  min-w-[395px] max-w-[395px] lg:min-w-[32rem] lg:max-w-[32rem]
+  w-[calc(100vw_-_24px)] min-w-[calc(100vw_-_24px)] max-w-[calc(100vw_-_24px)] sm:min-w-[395px] sm:max-w-[395px] lg:min-w-[32rem] lg:max-w-[32rem]
   rounded-lg border-8 bg-white
   h-[calc(100vh_-_32px)]
   p-4

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -117,7 +117,10 @@
   overflow-y-auto
   overflow-x-hidden
   mx-2 mt-2
-  w-[calc(100vw_-_24px)] min-w-[calc(100vw_-_24px)] max-w-[calc(100vw_-_24px)] sm:min-w-[395px] sm:max-w-[395px] lg:min-w-[32rem] lg:max-w-[32rem]
+  w-[calc(100vw_-_24px)] min-w-[calc(100vw_-_24px)] max-w-[calc(100vw_-_24px)]
+  {card.type === 'article' || card.type === 'editor'
+    ? 'sm:min-w-[500px] sm:max-w-[500px] lg:min-w-[48rem] lg:max-w-[48rem] xl:min-w-[56rem] xl:max-w-[56rem]' 
+    : 'sm:min-w-[395px] sm:max-w-[395px] lg:min-w-[32rem] lg:max-w-[32rem]'}
   rounded-lg border-8 bg-white
   h-[calc(100vh_-_32px)]
   p-4

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -1,0 +1,46 @@
+export interface DiffLine {
+  type: 'added' | 'removed' | 'unmodified';
+  value: string;
+}
+
+/**
+ * Computes a line-by-line diff between two strings using the Longest Common Subsequence (LCS) algorithm.
+ */
+export function diffLines(oldStr: string, newStr: string): DiffLine[] {
+  const oldLines = oldStr.split(/\r?\n/);
+  const newLines = newStr.split(/\r?\n/);
+
+  const dp: number[][] = Array(oldLines.length + 1)
+    .fill(null)
+    .map(() => Array(newLines.length + 1).fill(0));
+
+  for (let i = 1; i <= oldLines.length; i++) {
+    for (let j = 1; j <= newLines.length; j++) {
+      if (oldLines[i - 1] === newLines[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  const result: DiffLine[] = [];
+  let i = oldLines.length;
+  let j = newLines.length;
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+      result.unshift({ type: 'unmodified', value: oldLines[i - 1] });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      result.unshift({ type: 'added', value: newLines[j - 1] });
+      j--;
+    } else if (i > 0 && (j === 0 || dp[i][j - 1] < dp[i - 1][j])) {
+      result.unshift({ type: 'removed', value: oldLines[i - 1] });
+      i--;
+    }
+  }
+
+  return result;
+}

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -17,6 +17,7 @@ const startTime = Math.round(Date.now() / 1000);
 
 export const reactionKind = 7;
 export const wikiKind = 30818;
+export const gitPatchKind = 1617;
 
 export const signer = {
   getPublicKey: async () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,7 +4,7 @@ export type EditorData = {
   title: string;
   summary: string;
   content: string;
-  previous: ArticleCard | undefined;
+  previous: Card | undefined;
 };
 
 export type Card =

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,6 +16,18 @@
   let scrollLeft: number;
   let slider: HTMLElement;
 
+  let isWelcomeCollapsed = $state(false);
+  let prevCardsLength = 0;
+
+  $effect(() => {
+    if ($cards.length < 2) {
+      isWelcomeCollapsed = false;
+    } else if ($cards.length >= 2 && prevCardsLength < 2) {
+      isWelcomeCollapsed = true; // Auto-collapse when second column is opened
+    }
+    prevCardsLength = $cards.length;
+  });
+
   onMount(() => {
     document.addEventListener('mousedown', onMouseDown);
     document.addEventListener('mouseup', onMouseUp);
@@ -69,7 +81,11 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
 <div class="flex overflow-x-scroll pb-2" draggable="false" bind:this={slider}>
-  <CardElement card={{ type: 'welcome', id: -1 }} />
+  <CardElement 
+    card={{ type: 'welcome', id: -1 }} 
+    collapsed={$cards.length >= 2 && isWelcomeCollapsed}
+    onToggleCollapse={() => isWelcomeCollapsed = !isWelcomeCollapsed}
+  />
 
   {#each $cards as card (card.id)}
     <CardElement {card} />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -77,6 +77,4 @@
 
   <!-- this is just empty -->
   {@render children?.()}
-
-  <CardElement card={{ type: 'new', id: -1 }} />
 </div>


### PR DESCRIPTION
This PR introduces several enhancements to improve article discovery, linking, and layout utilization:

1. **Inline Article Lookup & Link Insertion**: Added an inline search widget in the Editor card to quickly find existing articles and insert reference wikilinks (`[[Title]]`).
2. **Auto-Redirect for Wikilinks**: Clicking a wikilink now automatically resolves to the exact match (checking preferred authors first, and falling back to the best Web of Trust match after a brief 800ms timeout) instead of leaving the user on the search card.
3. **Collapsible Welcome Column**: On wider screens, the Welcome/Search column collapses into a slim 64px vertical sidebar when 2 or more additional cards are visible, maximizing workspace space. Includes a manual toggle chevron button and vertical text labels.
4. **TypeScript Fixes**: Corrected type checking definitions in `types.ts` and `Editor.svelte` to support generic card history navigation on Editor close.