### PR TITLE
Wikistr Enhancements: wiki features, private tags, improved link routing, local history & version tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# wikistr
+
+A modern, decentralized, Nostr-based wiki client built with Svelte 5, TailwindCSS, and Vite.
+
+## 🚀 Key Highlights & Features
+
+- **Decentralized Wiki Articles (Kind 30818)**: Read, write, and version wiki content stored directly on Nostr relays.
+- **Interactive Multi-Column Layout**: Browse content using a side-by-side deck system. Open search results, article pages, settings, and editors in parallel panels.
+- **Relay Configuration & Outbox Support**:
+  - Configure custom read/write relays.
+  - Automatically merges default fallback relays with the user's personal Nostr relay lists (Kind 10002) for robust publishing.
+  - Fetches from followed authors' relays to discover related articles.
+- **Patches & Suggestions (Kind 1617)**: Propose edits to articles authored by others via Git-like patch events.
+- **Private Tags & Bookmarks (Kind 30003)**: Categorize, tag, and bookmark articles privately, with cross-device synchronization encrypted via NIP-04.
+- **Local History & Pinning**: Keep track of recently viewed articles and pin favorites to the dashboard dashboard.
+- **Svelte 5 Powered**: Engineered with the latest Svelte 5 reactive Runes (`$state`, `$derived`, `$effect`) for responsive UI state management.
+
+---
+
+## 🛠️ Tech Stack
+
+- **Framework**: [Svelte 5](https://svelte.dev/) & [SvelteKit](https://kit.svelte.dev/)
+- **Build Tool**: [Vite](https://vitejs.dev/)
+- **Styling**: [TailwindCSS](https://tailwindcss.com/)
+- **Nostr Libraries**: `@nostr/tools` & `@nostr/gadgets`
+- **Storage**: IndexedDB (`idb-keyval`) & LocalStorage
+
+---
+
+## ⚙️ Getting Started
+
+### Prerequisites
+
+Ensure you have [Node.js](https://nodejs.org/) installed (v18+ recommended).
+
+### Installation
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Run the development server:
+   ```bash
+   npm run dev
+   ```
+
+3. Open your browser and navigate to `http://localhost:5173`.
+
+### Commands
+
+- `npm run dev`: Starts the local dev server.
+- `npm run build`: Builds the static site assets.
+- `npx svelte-check`: Runs type-checks and diagnostics for Svelte files.
+
+---
+
+## 📄 License
+
+This project is open-source. Refer to the repository metadata for details.

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -1,0 +1,883 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_NAME="wikistr"
+SERVICE_NAME="wikistr"
+INSTALL_DIR="/var/www/wikistr"
+SERVICE_USER="www-data"
+SERVICE_GROUP="www-data"
+PORT="3000"
+PROXY_MODE="auto"
+DOMAIN=""
+CADDY_EMAIL=""
+SSH_PORT="22"
+DRY_RUN=false
+SKIP_BUILD=false
+SSH_TARGET=""
+SSH_LOGIN_USER=""
+SSH_CONTROL_PATH="${TMPDIR:-/tmp}/wikistr-ssh-%C"
+REMOTE_STAGE_DIR="/tmp/${SERVICE_NAME}-deploy"
+TOTAL_STEPS=4
+CURRENT_STEP=0
+CURRENT_STEP_LABEL=""
+TTY_AVAILABLE=false
+USE_COLOR=false
+SPINNER_PID=""
+SPINNER_LABEL=""
+SPINNER_RUNNING=false
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REMOTE_SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+
+log() {
+	printf '[deploy] %s\n' "$*"
+}
+
+warn() {
+	printf '[deploy] warning: %s\n' "$*" >&2
+}
+
+die() {
+	printf '[deploy] error: %s\n' "$*" >&2
+	exit 1
+}
+
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+	USE_COLOR=true
+fi
+
+if [[ "$USE_COLOR" == true ]]; then
+	C_RESET=$'\033[0m'
+	C_BOLD=$'\033[1m'
+	C_DIM=$'\033[2m'
+	C_RED=$'\033[31m'
+	C_GREEN=$'\033[32m'
+	C_YELLOW=$'\033[33m'
+	C_BLUE=$'\033[34m'
+	C_CYAN=$'\033[36m'
+else
+	C_RESET=''
+	C_BOLD=''
+	C_DIM=''
+	C_RED=''
+	C_GREEN=''
+	C_YELLOW=''
+	C_BLUE=''
+	C_CYAN=''
+fi
+
+paint() {
+	local color="$1"
+	shift
+	printf '%s%s%s' "$color" "$*" "$C_RESET"
+}
+
+status_good() { paint "$C_GREEN" "$*"; }
+status_bad() { paint "$C_RED" "$*"; }
+status_warn() { paint "$C_YELLOW" "$*"; }
+status_info() { paint "$C_CYAN" "$*"; }
+
+hr() {
+	local width="${1:-72}"
+	printf '%*s\n' "$width" '' | tr ' ' '-'
+}
+
+panel_line() {
+	local text="$1"
+	printf '| %-*s |\n' 68 "${text:0:68}"
+}
+
+render_header() {
+	local proxy_display="$PROXY_MODE"
+	if [[ "$PROXY_MODE" == "auto" && -n "$proxy_mode_resolved" ]]; then
+		proxy_display="auto -> ${proxy_mode_resolved}"
+	fi
+
+	printf '\n'
+	hr
+	panel_line "$(status_info "wikistr deploy installer")"
+	hr
+	panel_line "target   : ${SSH_TARGET}"
+	panel_line "install  : ${INSTALL_DIR}"
+	panel_line "service  : ${SERVICE_NAME}"
+	panel_line "port     : ${PORT}"
+	panel_line "proxy    : ${proxy_display}"
+	panel_line "domain   : ${DOMAIN:-<none>}"
+	panel_line "build    : $([[ "$SKIP_BUILD" == true ]] && printf 'skip local build' || printf 'npm ci + npm run build')"
+	panel_line "tty      : $([[ "$TTY_AVAILABLE" == true ]] && printf 'interactive' || printf 'non-interactive')"
+	hr
+	printf '\n'
+}
+
+spinner_start() {
+	local label="$1"
+	SPINNER_LABEL="$label"
+	SPINNER_RUNNING=true
+	if [[ "$USE_COLOR" != true ]]; then
+		return 0
+	fi
+
+	(
+		local frames=('|' '/' '-' '\\')
+		local i=0
+		while :; do
+			printf '\r%s %s' "$(status_info "${frames[i % 4]}")" "$SPINNER_LABEL" >&2
+			i=$((i + 1))
+			sleep 0.1
+		done
+	) &
+	SPINNER_PID=$!
+}
+
+spinner_stop() {
+	local result="${1:-0}"
+	SPINNER_RUNNING=false
+	if [[ -n "$SPINNER_PID" ]]; then
+		kill "$SPINNER_PID" 2>/dev/null || true
+		wait "$SPINNER_PID" 2>/dev/null || true
+		SPINNER_PID=""
+	fi
+	if [[ "$USE_COLOR" == true ]]; then
+		printf '\r%*s\r' 120 '' >&2
+	fi
+	if [[ "$result" == 0 ]]; then
+		printf '%s %s\n' "$(status_good '[ok]')" "$SPINNER_LABEL"
+	else
+		printf '%s %s\n' "$(status_bad '[fail]')" "$SPINNER_LABEL"
+	fi
+	SPINNER_LABEL=""
+}
+
+run_spinner() {
+	local label="$1"
+	shift
+	if [[ "$USE_COLOR" != true ]]; then
+		"$@"
+		return
+	fi
+
+	spinner_start "$label"
+	if "$@"; then
+		spinner_stop 0
+	else
+		local rc=$?
+		spinner_stop "$rc"
+		return "$rc"
+	fi
+}
+
+step_begin() {
+	CURRENT_STEP=$((CURRENT_STEP + 1))
+	CURRENT_STEP_LABEL="$1"
+	printf '\n%s [%d/%d] %s\n' "$(status_info '>>>')" "$CURRENT_STEP" "$TOTAL_STEPS" "$CURRENT_STEP_LABEL"
+}
+
+step_done() {
+	printf '%s [%d/%d] %s\n' "$(status_good '[ok]')" "$CURRENT_STEP" "$TOTAL_STEPS" "$CURRENT_STEP_LABEL"
+	CURRENT_STEP_LABEL=""
+}
+
+on_error() {
+	local exit_code="$1"
+	local line_no="$2"
+	if [[ -n "$CURRENT_STEP_LABEL" ]]; then
+		printf '\n%s [%d/%d] %s\n' "$(status_bad '[fail]')" "$CURRENT_STEP" "$TOTAL_STEPS" "$CURRENT_STEP_LABEL" >&2
+	fi
+	printf '%s command failed at line %s (exit %s)\n' "$(status_bad '[deploy] error:')" "$line_no" "$exit_code" >&2
+}
+
+usage() {
+	cat <<'EOF'
+Usage:
+  scripts/deploy-remote.sh --host user@server [options]
+
+Options:
+  --host <user@host>       SSH target for the remote server
+  --port <port>            App port on the remote host (default: 3000)
+  --install-dir <path>     Remote install path (default: /var/www/wikistr)
+  --service-user <user>    Systemd service user (default: www-data)
+  --service-group <group>  Systemd service group (default: www-data)
+  --proxy auto|caddy|nginx|none  Reverse proxy mode (default: auto)
+  --domain <hostname>      Reverse proxy hostname (required for caddy/nginx)
+  --caddy-email <email>    Caddy ACME contact email
+  --ssh-port <port>        SSH port (default: 22)
+  --skip-build             Skip the local build step
+  --dry-run                Print actions without executing them
+  -h, --help               Show this help
+
+Environment overrides:
+  WIKISTR_SSH_TARGET, WIKISTR_PORT, WIKISTR_INSTALL_DIR,
+  WIKISTR_SERVICE_USER, WIKISTR_SERVICE_GROUP, WIKISTR_PROXY,
+  WIKISTR_DOMAIN, WIKISTR_CADDY_EMAIL, WIKISTR_SSH_PORT,
+  WIKISTR_DRY_RUN, WIKISTR_SKIP_BUILD
+EOF
+}
+
+is_true() {
+	case "${1,,}" in
+		1|true|yes|on) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+run_local() {
+	if [[ "$DRY_RUN" == true ]]; then
+		printf '[dry-run] '
+		printf '%q ' "$@"
+		printf '\n'
+		return 0
+	fi
+	"$@"
+}
+
+ssh_common_opts() {
+	printf -- '-o ControlMaster=auto -o ControlPersist=10m -o ControlPath=%q' "$SSH_CONTROL_PATH"
+}
+
+ssh_interactive_opts() {
+	printf '%s' '-tt -o RequestTTY=force'
+}
+
+open_ssh_master() {
+	if [[ "$DRY_RUN" == true ]]; then
+		printf '[dry-run] ssh -MNf -p %s %s\n' "$SSH_PORT" "$SSH_TARGET"
+		return 0
+	fi
+	ssh -MNf -p "$SSH_PORT" \
+		-o "ControlMaster=auto" \
+		-o "ControlPersist=10m" \
+		-o "ControlPath=${SSH_CONTROL_PATH}" \
+		"$SSH_TARGET"
+}
+
+run_remote() {
+	local script="$1"
+	shift || true
+	local remote_args
+	printf -v remote_args '%q %q %q %q %q %q %q %q' \
+		"$INSTALL_DIR" "$SERVICE_NAME" "$SERVICE_USER" "$SERVICE_GROUP" "$PORT" "$PROXY_MODE" "$DOMAIN" "$CADDY_EMAIL"
+	if [[ "$DRY_RUN" == true ]]; then
+		printf '[dry-run] ssh -tt -p %s -o ControlMaster=auto -o ControlPersist=10m -o ControlPath=%q %s bash -s -- %s\n' \
+			"$SSH_PORT" "$SSH_CONTROL_PATH" "$SSH_TARGET" "$remote_args"
+		printf '%s\n' "$script"
+		return 0
+	fi
+	ssh -tt -p "$SSH_PORT" \
+		-o "ControlMaster=auto" \
+		-o "ControlPersist=10m" \
+		-o "ControlPath=${SSH_CONTROL_PATH}" \
+		"$SSH_TARGET" "bash -s -- $remote_args" <<<"$script"
+}
+
+build_app() {
+	if [[ "$DRY_RUN" == true ]]; then
+		step_begin "local build (dry-run)"
+		log "skipping local build"
+		step_done
+		return
+	fi
+	if [[ "$SKIP_BUILD" == true ]]; then
+		step_begin "local build (skipped)"
+		log "skipping local build"
+		step_done
+		return
+	fi
+
+	step_begin "install local dependencies"
+	(
+		cd "$REPO_ROOT"
+		npm ci
+	)
+	step_done
+
+	step_begin "build local app"
+	(
+		cd "$REPO_ROOT"
+		npm run build
+	)
+	step_done
+}
+
+sync_app() {
+	step_begin "sync repository"
+	log "copying repo to ${SSH_TARGET}:${REMOTE_STAGE_DIR}"
+	if [[ "$DRY_RUN" != true ]]; then
+		open_ssh_master
+	fi
+	run_local rsync -az --delete --no-owner --no-group -e "ssh -p ${SSH_PORT} -o ControlMaster=auto -o ControlPersist=10m -o ControlPath=${SSH_CONTROL_PATH}" \
+		--exclude='.git' \
+		--exclude='.claude' \
+		--exclude='node_modules' \
+		--exclude='build' \
+		--exclude='coverage' \
+		"${REPO_ROOT}/" "${SSH_TARGET}:${REMOTE_STAGE_DIR}/"
+
+	if [[ -d "${REPO_ROOT}/build" ]]; then
+		log "copying build artifacts"
+		run_local rsync -az --delete --no-owner --no-group -e "ssh -p ${SSH_PORT} -o ControlMaster=auto -o ControlPersist=10m -o ControlPath=${SSH_CONTROL_PATH}" \
+			"${REPO_ROOT}/build/" "${SSH_TARGET}:${REMOTE_STAGE_DIR}/build/"
+	fi
+	step_done
+}
+
+install_remote_service() {
+	step_begin "install remote service"
+	local remote_script
+	remote_script="$(cat <<'EOF'
+set -Eeuo pipefail
+
+INSTALL_DIR="$1"
+STAGING_DIR="$2"
+SERVICE_NAME="$3"
+SERVICE_USER="$4"
+SERVICE_GROUP="$5"
+PORT="$6"
+PROXY_MODE="$7"
+DOMAIN="$8"
+CADDY_EMAIL="$9"
+DRY_RUN=false
+CURRENT_STEP=0
+CURRENT_STEP_LABEL=""
+
+log() {
+	printf '[remote] %s\n' "$*"
+}
+
+warn() {
+	printf '[remote] warning: %s\n' "$*" >&2
+}
+
+die() {
+	printf '[remote] error: %s\n' "$*" >&2
+	exit 1
+}
+
+hr() {
+	local width="${1:-64}"
+	printf '%*s\n' "$width" '' | tr ' ' '-'
+}
+
+panel_line() {
+	local text="$1"
+	printf '| %-*s |\n' 60 "${text:0:60}"
+}
+
+remote_step_begin() {
+	CURRENT_STEP=$((CURRENT_STEP + 1))
+	CURRENT_STEP_LABEL="$1"
+	printf '\n[remote %d] >>> %s\n' "$CURRENT_STEP" "$CURRENT_STEP_LABEL"
+}
+
+remote_step_done() {
+	printf '[remote %d] [ok] %s\n' "$CURRENT_STEP" "$CURRENT_STEP_LABEL"
+	CURRENT_STEP_LABEL=""
+}
+
+sudo_run() {
+	sudo -n "$@"
+}
+
+port_is_listening() {
+	ss -H -ltn "sport = :${PORT}" | grep -q .
+}
+
+service_is_active() {
+	sudo_run systemctl is-active --quiet "${SERVICE_NAME}.service"
+}
+
+wait_for_ready() {
+	local attempt
+	for attempt in $(seq 1 30); do
+		if service_is_active && port_is_listening; then
+			return 0
+		fi
+		sleep 1
+	done
+
+	warn "service did not become ready on port ${PORT}"
+	sudo_run systemctl status "${SERVICE_NAME}.service" --no-pager -l || true
+	sudo_run journalctl -u "${SERVICE_NAME}.service" --no-pager -n 100 || true
+	die "service failed to bind to port ${PORT}"
+}
+
+choose_port() {
+	local candidate="$PORT"
+	while ss -H -ltn "sport = :${candidate}" | grep -q .; do
+		candidate=$((candidate + 1))
+		if (( candidate > 65535 )); then
+			die "no free ports available starting from ${PORT}"
+		fi
+	done
+	if [[ "$candidate" != "$PORT" ]]; then
+		warn "port ${PORT} is in use; using ${candidate} instead"
+	fi
+	PORT="$candidate"
+}
+
+verify_build_artifacts() {
+	if [[ "${DRY_RUN:-false}" == true ]]; then
+		return
+	fi
+	if [[ ! -f "${INSTALL_DIR}/build/index.html" ]]; then
+		die "missing build artifact at ${INSTALL_DIR}/build/index.html"
+	fi
+}
+
+is_true() {
+	case "${1,,}" in
+		1|true|yes|on) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+trim() {
+	sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}
+
+managed_marker="# managed by wikistr"
+proxy_mode_resolved="$PROXY_MODE"
+
+command -v python3 >/dev/null 2>&1 || die "python3 is required on the remote server"
+command -v systemctl >/dev/null 2>&1 || die "systemctl is required on the remote server"
+command -v ss >/dev/null 2>&1 || die "ss is required on the remote server"
+command -v curl >/dev/null 2>&1 || die "curl is required on the remote server"
+command -v rsync >/dev/null 2>&1 || die "rsync is required on the remote server"
+
+log "refreshing sudo credentials"
+sudo -v
+
+if [[ "$proxy_mode_resolved" == "auto" ]]; then
+	if command -v caddy >/dev/null 2>&1; then
+		proxy_mode_resolved="caddy"
+	elif command -v nginx >/dev/null 2>&1; then
+		proxy_mode_resolved="nginx"
+	else
+		proxy_mode_resolved="none"
+	fi
+fi
+
+printf '\n'
+hr
+panel_line "wikistr remote installer"
+hr
+panel_line "install  : ${INSTALL_DIR}"
+panel_line "service  : ${SERVICE_NAME}"
+panel_line "port     : ${PORT}"
+panel_line "proxy    : ${proxy_mode_resolved}"
+panel_line "domain   : ${DOMAIN:-<none>}"
+hr
+printf '\n'
+
+remote_step_begin "prepare install directory"
+if [[ "$proxy_mode_resolved" != "none" && -z "$DOMAIN" ]]; then
+	die "a domain is required when reverse proxying"
+fi
+sudo_run install -d -m 0755 "$INSTALL_DIR"
+sudo_run rsync -a --delete "$STAGING_DIR"/ "$INSTALL_DIR"/
+sudo_run chown -R "${SERVICE_USER}:${SERVICE_GROUP}" "$INSTALL_DIR"
+remote_step_done
+
+write_managed_file() {
+	local target="$1"
+	local content="$2"
+	if [[ -f "$target" ]] && ! grep -qF "$managed_marker" "$target"; then
+		die "${target} exists and is not managed by this script; refusing to overwrite"
+	fi
+	local tmp
+	tmp="$(mktemp)"
+	printf '%s\n' "$content" >"$tmp"
+	sudo_run install -d -m 0755 "$(dirname "$target")"
+	sudo_run install -m 0644 "$tmp" "$target"
+	rm -f "$tmp"
+}
+
+install_service() {
+	remote_step_begin "write systemd service"
+	cat >/tmp/${SERVICE_NAME}.service <<SERVICEEOF
+[Unit]
+Description=${SERVICE_NAME} static web app
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=${INSTALL_DIR}
+User=${SERVICE_USER}
+Group=${SERVICE_GROUP}
+ExecStart=/usr/bin/python3 ${INSTALL_DIR}/scripts/spa-http-server.py ${INSTALL_DIR}/build --bind 127.0.0.1 --port ${PORT}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+SERVICEEOF
+
+	sudo_run install -m 0644 /tmp/${SERVICE_NAME}.service /etc/systemd/system/${SERVICE_NAME}.service
+	rm -f /tmp/${SERVICE_NAME}.service
+	remote_step_done
+}
+
+detect_caddy_snippet_dir() {
+	local main_file="/etc/caddy/Caddyfile"
+	local dir
+	if [[ -n "${WIKISTR_CADDY_SNIPPET_DIR:-}" ]]; then
+		printf '%s' "$WIKISTR_CADDY_SNIPPET_DIR"
+		return 0
+	fi
+	if [[ -f "$main_file" ]]; then
+		for dir in /etc/caddy/conf.d /etc/caddy/Caddyfile.d; do
+			if grep -qE "^[[:space:]]*import[[:space:]].*${dir}/\\*\\.caddy" "$main_file" 2>/dev/null; then
+				printf '%s' "$dir"
+				return 0
+			fi
+		done
+	fi
+	for dir in /etc/caddy/conf.d /etc/caddy/Caddyfile.d; do
+		if [[ -d "$dir" ]]; then
+			printf '%s' "$dir"
+			return 0
+		fi
+	done
+	printf '%s' /etc/caddy/conf.d
+}
+
+configure_caddy() {
+	local domain="$1"
+	local port="$2"
+	local main_file="/etc/caddy/Caddyfile"
+	local snippet_dir snippet_file import_line content
+	remote_step_begin "configure caddy"
+	snippet_dir="$(detect_caddy_snippet_dir)"
+	snippet_file="${snippet_dir}/${SERVICE_NAME}.caddy"
+	import_line="import ${snippet_dir}/*.caddy"
+
+	log "configuring caddy for ${domain}"
+	sudo_run install -d -m 0755 "$snippet_dir"
+	content="${managed_marker}
+${domain} {
+	${CADDY_EMAIL:+tls ${CADDY_EMAIL}}
+	encode zstd gzip
+	reverse_proxy localhost:${port}
+}"
+	write_managed_file "$snippet_file" "$content"
+
+	if [[ ! -f "$main_file" ]]; then
+		write_managed_file "$main_file" "${managed_marker}
+${import_line}"
+	else
+		if grep -qE '^[[:space:]]*import[[:space:]].*(/etc/caddy/)?(conf\.d|Caddyfile\.d)/\*\.caddy' "$main_file"; then
+			log "existing Caddyfile already imports a snippet directory; leaving it unchanged"
+		elif grep -qF "$managed_marker" "$main_file"; then
+			log "existing Caddyfile is managed by wikistr; adding snippet import"
+			local current_content
+			current_content="$(cat "$main_file")"
+			write_managed_file "$main_file" "${current_content}
+
+${import_line}"
+		else
+			warn "existing Caddyfile does not import ${snippet_dir}; not modifying it"
+			warn "add this line manually if needed: ${import_line}"
+		fi
+	fi
+
+	if command -v caddy >/dev/null 2>&1; then
+		sudo_run caddy validate --config "$main_file"
+	fi
+	remote_step_done
+}
+
+detect_nginx_style() {
+	local nginx_main="/etc/nginx/nginx.conf"
+	if [[ -n "${WIKISTR_NGINX_STYLE:-}" ]]; then
+		printf '%s' "$WIKISTR_NGINX_STYLE"
+		return 0
+	fi
+	if [[ -f "$nginx_main" ]] && grep -qE 'include[[:space:]]+.*/conf\.d/\*\.conf;' "$nginx_main"; then
+		printf '%s' "conf.d"
+		return 0
+	fi
+	if [[ -f "$nginx_main" ]] && grep -qE 'include[[:space:]]+.*/sites-enabled/\*;' "$nginx_main"; then
+		printf '%s' "sites"
+		return 0
+	fi
+	printf '%s' "unknown"
+}
+
+configure_nginx() {
+	local domain="$1"
+	local port="$2"
+	local style
+	local nginx_main="/etc/nginx/nginx.conf"
+	style="$(detect_nginx_style)"
+
+	log "configuring nginx for ${domain}"
+	remote_step_begin "configure nginx"
+	case "$style" in
+		conf.d)
+			local conf_file="/etc/nginx/conf.d/${SERVICE_NAME}.conf"
+			local content
+			content="${managed_marker}
+server {
+	listen 80;
+	server_name ${domain};
+
+	location / {
+		proxy_pass http://127.0.0.1:${port};
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade \$http_upgrade;
+		proxy_set_header Connection \"upgrade\";
+		proxy_set_header Host \$host;
+		proxy_set_header X-Real-IP \$remote_addr;
+		proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto \$scheme;
+		proxy_read_timeout 3600;
+		proxy_send_timeout 3600;
+	}
+}"
+			write_managed_file "$conf_file" "$content"
+			;;
+		sites)
+			local sites_available="/etc/nginx/sites-available/${SERVICE_NAME}.conf"
+			local sites_enabled="/etc/nginx/sites-enabled/${SERVICE_NAME}.conf"
+			local content
+			content="${managed_marker}
+server {
+	listen 80;
+	server_name ${domain};
+
+	location / {
+		proxy_pass http://127.0.0.1:${port};
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade \$http_upgrade;
+		proxy_set_header Connection \"upgrade\";
+		proxy_set_header Host \$host;
+		proxy_set_header X-Real-IP \$remote_addr;
+		proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto \$scheme;
+		proxy_read_timeout 3600;
+		proxy_send_timeout 3600;
+	}
+}"
+			write_managed_file "$sites_available" "$content"
+			if [[ -e "$sites_enabled" && ! -L "$sites_enabled" ]]; then
+				die "${sites_enabled} exists and is not a symlink; refusing to overwrite"
+			fi
+			if [[ -L "$sites_enabled" ]]; then
+				local current_target
+				current_target="$(readlink "$sites_enabled")"
+				if [[ "$current_target" != "$sites_available" ]]; then
+					die "${sites_enabled} points to ${current_target}; refusing to change it"
+				fi
+			else
+				sudo_run ln -s "$sites_available" "$sites_enabled"
+			fi
+			;;
+		unknown)
+			warn "/etc/nginx/nginx.conf does not clearly enable conf.d or sites-enabled"
+			warn "leaving nginx configuration unchanged"
+			return 0
+			;;
+	esac
+
+	sudo_run nginx -t
+	sudo_run systemctl reload nginx 2>/dev/null || sudo_run systemctl restart nginx
+	remote_step_done
+}
+
+configure_proxy() {
+	case "$proxy_mode_resolved" in
+		none)
+			log "reverse proxy disabled"
+			return 0
+			;;
+		caddy)
+			command -v caddy >/dev/null 2>&1 || die "caddy is not installed on the remote server"
+			configure_caddy "$DOMAIN" "$PORT"
+			;;
+		nginx)
+			command -v nginx >/dev/null 2>&1 || die "nginx is not installed on the remote server"
+			configure_nginx "$DOMAIN" "$PORT"
+			;;
+		*)
+			die "unknown proxy mode: $proxy_mode_resolved"
+			;;
+	esac
+}
+
+log "normalizing ownership"
+sudo_run chmod 0755 "$INSTALL_DIR"
+
+log "stopping existing service"
+sudo_run systemctl stop "${SERVICE_NAME}.service" 2>/dev/null || true
+
+if port_is_listening; then
+	choose_port
+	log "selected port ${PORT}"
+fi
+
+verify_build_artifacts
+
+install_service
+
+log "reloading systemd"
+sudo_run systemctl daemon-reload
+sudo_run systemctl reset-failed "${SERVICE_NAME}.service" 2>/dev/null || true
+sudo_run systemctl enable "${SERVICE_NAME}.service"
+sudo_run systemctl start "${SERVICE_NAME}.service"
+
+remote_step_begin "smoke test"
+wait_for_ready
+curl -fsS "http://127.0.0.1:${PORT}/" >/dev/null
+curl -fsS "http://127.0.0.1:${PORT}/does-not-exist" >/dev/null
+remote_step_done
+
+configure_proxy
+
+log "deployment complete"
+EOF
+)"
+	local remote_script_file
+	remote_script_file="$(mktemp)"
+	printf '%s\n' "$remote_script" >"$remote_script_file"
+	if [[ "$DRY_RUN" == true ]]; then
+		local remote_args
+		printf -v remote_args '%q %q %q %q %q %q %q %q %q' \
+			"$INSTALL_DIR" "$REMOTE_STAGE_DIR" "$SERVICE_NAME" "$SERVICE_USER" "$SERVICE_GROUP" "$PORT" "$PROXY_MODE" "$DOMAIN" "$CADDY_EMAIL"
+		printf '[dry-run] scp -P %s -o ControlMaster=auto -o ControlPersist=10m -o ControlPath=%q %q %q:%q\n' \
+			"$SSH_PORT" "$SSH_CONTROL_PATH" "$remote_script_file" "$SSH_TARGET" "/tmp/${SERVICE_NAME}-deploy.sh"
+		printf '[dry-run] ssh -tt -p %s -o ControlMaster=auto -o ControlPersist=10m -o ControlPath=%q %q bash %q %s\n' \
+			"$SSH_PORT" "$SSH_CONTROL_PATH" "$SSH_TARGET" "/tmp/${SERVICE_NAME}-deploy.sh" "$remote_args"
+		rm -f "$remote_script_file"
+		step_done
+		return 0
+	fi
+	open_ssh_master
+	scp -P "$SSH_PORT" \
+		-o "ControlMaster=auto" \
+		-o "ControlPersist=10m" \
+		-o "ControlPath=${SSH_CONTROL_PATH}" \
+		"$remote_script_file" "$SSH_TARGET:/tmp/${SERVICE_NAME}-deploy.sh"
+	rm -f "$remote_script_file"
+	ssh -tt -p "$SSH_PORT" \
+		-o "ControlMaster=auto" \
+		-o "ControlPersist=10m" \
+		-o "ControlPath=${SSH_CONTROL_PATH}" \
+		"$SSH_TARGET" "bash /tmp/${SERVICE_NAME}-deploy.sh $(printf '%q ' "$INSTALL_DIR" "$REMOTE_STAGE_DIR" "$SERVICE_NAME" "$SERVICE_USER" "$SERVICE_GROUP" "$PORT" "$PROXY_MODE" "$DOMAIN" "$CADDY_EMAIL")"
+	step_done
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--host)
+			SSH_TARGET="${2:-}"
+			shift 2
+			;;
+		--port)
+			PORT="${2:-}"
+			shift 2
+			;;
+		--install-dir)
+			INSTALL_DIR="${2:-}"
+			shift 2
+			;;
+		--service-user)
+			SERVICE_USER="${2:-}"
+			shift 2
+			;;
+		--service-group)
+			SERVICE_GROUP="${2:-}"
+			shift 2
+			;;
+		--proxy)
+			PROXY_MODE="${2:-}"
+			shift 2
+			;;
+		--domain)
+			DOMAIN="${2:-}"
+			shift 2
+			;;
+		--caddy-email)
+			CADDY_EMAIL="${2:-}"
+			shift 2
+			;;
+		--ssh-port)
+			SSH_PORT="${2:-}"
+			shift 2
+			;;
+		--skip-build)
+			SKIP_BUILD=true
+			shift
+			;;
+		--dry-run)
+			DRY_RUN=true
+			shift
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			die "unknown option: $1"
+			;;
+	esac
+done
+
+if [[ -z "$SSH_TARGET" ]]; then
+	SSH_TARGET="${WIKISTR_SSH_TARGET:-}"
+fi
+if [[ -z "$SSH_TARGET" ]]; then
+	usage
+	die "missing required option: --host"
+fi
+
+if [[ "$PORT" == "3000" && -n "${WIKISTR_PORT:-}" ]]; then
+	PORT="$WIKISTR_PORT"
+fi
+if [[ "$INSTALL_DIR" == "/var/www/wikistr" && -n "${WIKISTR_INSTALL_DIR:-}" ]]; then
+	INSTALL_DIR="$WIKISTR_INSTALL_DIR"
+fi
+if [[ "$SERVICE_USER" == "www-data" && -n "${WIKISTR_SERVICE_USER:-}" ]]; then
+	SERVICE_USER="$WIKISTR_SERVICE_USER"
+fi
+if [[ "$SERVICE_GROUP" == "www-data" && -n "${WIKISTR_SERVICE_GROUP:-}" ]]; then
+	SERVICE_GROUP="$WIKISTR_SERVICE_GROUP"
+fi
+if [[ "$PROXY_MODE" == "auto" && -n "${WIKISTR_PROXY:-}" ]]; then
+	PROXY_MODE="$WIKISTR_PROXY"
+fi
+if [[ -z "$DOMAIN" ]]; then
+	DOMAIN="${WIKISTR_DOMAIN:-}"
+fi
+if [[ -z "$CADDY_EMAIL" ]]; then
+	CADDY_EMAIL="${WIKISTR_CADDY_EMAIL:-}"
+fi
+if [[ "$SSH_PORT" == "22" && -n "${WIKISTR_SSH_PORT:-}" ]]; then
+	SSH_PORT="$WIKISTR_SSH_PORT"
+fi
+if [[ "$DRY_RUN" == false && -n "${WIKISTR_DRY_RUN:-}" ]]; then
+	is_true "$WIKISTR_DRY_RUN" && DRY_RUN=true || true
+fi
+if [[ "$SKIP_BUILD" == false && -n "${WIKISTR_SKIP_BUILD:-}" ]]; then
+	is_true "$WIKISTR_SKIP_BUILD" && SKIP_BUILD=true || true
+fi
+
+proxy_mode_resolved="$PROXY_MODE"
+
+trap 'on_error $? $LINENO' ERR
+
+if [[ "$DRY_RUN" == true ]]; then
+	log "performing dry-run deployment"
+fi
+
+if [[ ! -t 0 ]]; then
+	log "non-interactive tty"
+else
+	TTY_AVAILABLE=true
+fi
+
+render_header
+
+build_app
+sync_app
+install_remote_service
+
+log "done"

--- a/scripts/spa-http-server.py
+++ b/scripts/spa-http-server.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import mimetypes
+import os
+from functools import partial
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+
+class SpaRequestHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, directory: str | None = None, **kwargs):
+        super().__init__(*args, directory=directory, **kwargs)
+
+    def _resolve_path(self) -> Path:
+        parsed = urlparse(self.path)
+        request_path = unquote(parsed.path)
+        rel = request_path.lstrip("/")
+        candidate = Path(self.directory) / rel
+        if request_path in {"", "/"}:
+            return Path(self.directory) / "index.html"
+        if candidate.is_dir():
+            index = candidate / "index.html"
+            if index.exists():
+                return index
+        if candidate.exists():
+            return candidate
+        if Path(rel).suffix == "":
+            return Path(self.directory) / "index.html"
+        return candidate
+
+    def send_head(self):
+        path = self._resolve_path()
+        if not path.exists() or path.is_dir():
+            self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+            return None
+
+        content_type = mimetypes.guess_type(str(path))[0] or "application/octet-stream"
+        try:
+            file = path.open("rb")
+        except OSError:
+            self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+            return None
+
+        fs = path.stat()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(fs.st_size))
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        return file
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Serve a Vite build with SPA fallback")
+    parser.add_argument("directory", nargs="?", default="dist", help="Directory to serve")
+    parser.add_argument("--bind", default="127.0.0.1", help="Address to bind")
+    parser.add_argument("--port", type=int, default=3000, help="Port to listen on")
+    args = parser.parse_args()
+
+    directory = os.fspath(Path(args.directory).resolve())
+    handler = partial(SpaRequestHandler, directory=directory)
+    server = ThreadingHTTPServer((args.bind, args.port), handler)
+    try:
+        print(f"Serving {directory} on http://{args.bind}:{args.port}", flush=True)
+        server.serve_forever()
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -751,7 +751,7 @@
 
       <!-- Table of Contents -->
       {#if headings.length > 0}
-        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 max-w-sm">
+        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 w-full max-w-full sm:max-w-md lg:max-w-lg">
           <div class="text-xs font-bold text-stone-700 uppercase tracking-wider mb-2 border-b border-stone-200 pb-1 flex justify-between items-center">
             <span>Table of Contents</span>
           </div>

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy, onMount, untrack } from 'svelte';
+  import * as idbkv from 'idb-keyval';
   import type { EventTemplate, NostrEvent } from '@nostr/tools/pure';
   import { pool } from '@nostr/gadgets/global';
   import { loadRelayList } from '@nostr/gadgets/lists';
@@ -298,7 +299,21 @@
   let tagsList = $derived(event?.tags?.filter(([k]) => k === 't').map(([_, v]) => v) || []);
   let rawEvent = $derived(event ? JSON.stringify(event, null, 2) : '{...}');
 
+  let currentVersion = $derived.by<number>(() => {
+    if (!event) return 1;
+    const versionTag = event.tags.find(([k]) => k === 'version' || k === 'revision');
+    if (versionTag) {
+      const parsed = parseInt(versionTag[1], 10);
+      if (!isNaN(parsed)) return parsed;
+    }
+    return historyEvents.filter(h => h.pubkey === event?.pubkey).length || 1;
+  });
+
   function edit() {
+    const prevCard = { ...(card as ArticleCard) };
+    if (event) {
+      prevCard.actualEvent = event;
+    }
     replaceSelf({
       id: next(),
       type: 'editor',
@@ -307,7 +322,7 @@
         summary: summary || '',
         content: event?.content || '',
         tags: tagsList,
-        previous: card as ArticleCard
+        previous: prevCard
       }
     } as any);
   }
@@ -358,9 +373,31 @@
       loadedRelays = res;
     });
 
+    // Load local history from IndexedDB cache
+    const historyKey = `wikistr:history:${pubkey}:${dTag}`;
+    idbkv.get(historyKey).then((localHistory) => {
+      if (localHistory && Array.isArray(localHistory)) {
+        localHistory.forEach((evt) => {
+          if (!historyEvents.some((h) => h.id === evt.id)) {
+            historyEvents = [...historyEvents, evt].sort((a, b) => b.created_at - a.created_at);
+          }
+        });
+      }
+    });
+
     if (articleCard.actualEvent) {
       event = articleCard.actualEvent;
       seenOn = articleCard.relayHints || [];
+
+      // Save actualEvent to local history cache
+      idbkv.get(historyKey).then((localHistory) => {
+        const history = Array.isArray(localHistory) ? localHistory : [];
+        if (!history.some((h) => h.id === event!.id)) {
+          const updated = [...history, event!].sort((a, b) => b.created_at - a.created_at);
+          idbkv.set(historyKey, updated);
+          historyEvents = updated;
+        }
+      });
     }
 
     loadNostrUser(pubkey).then((user) => {
@@ -391,6 +428,17 @@
             if (!event || event.created_at < evt.created_at) {
               event = evt;
               setupLikes();
+
+              // Save event to local history cache
+              const historyKey = `wikistr:history:${pubkey}:${dTag}`;
+              idbkv.get(historyKey).then((localHistory) => {
+                const history = Array.isArray(localHistory) ? localHistory : [];
+                if (!history.some((h) => h.id === evt.id)) {
+                  const updated = [...history, evt].sort((a, b) => b.created_at - a.created_at);
+                  idbkv.set(historyKey, updated);
+                  historyEvents = updated;
+                }
+              });
             }
           }
         }
@@ -956,7 +1004,7 @@
         </div>
         <div>
           <span class="font-semibold text-stone-700">Revisions:</span>
-          {historyEvents.filter(h => h.pubkey === event?.pubkey).length || 1}
+          {currentVersion}
         </div>
         <div>
           <span class="font-semibold text-stone-700">Contributors:</span>

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -29,7 +29,7 @@
   let showSuggestionsPanel = $state(false);
   let selectedSuggestion = $state<NostrEvent | null>(null);
   let merging = $state(false);
-  let nOthers = $state<number | undefined>(undefined);
+
   let copied = $state(false);
   let isPinned = $state(false);
 
@@ -291,6 +291,8 @@
   let readRelays = $derived(loadedRelays ? loadedRelays.items.filter((ri: any) => ri.read).map((ri: any) => ri.url).concat(articleCard.relayHints || []) : []);
   let writeRelays = $derived(loadedRelays ? loadedRelays.items.filter((ri: any) => ri.write).map((ri: any) => ri.url).concat(articleCard.relayHints || []) : []);
 
+  let nOthers = $derived(historyEvents.length > 0 ? historyEvents.length : (articleCard.versions ? articleCard.versions.length : undefined));
+
   let title = $derived(event?.tags?.find?.(([k]) => k === 'title')?.[1] || dTag);
   let summary = $derived(event?.tags?.find(([k]) => k === 'summary')?.[1]);
   let tagsList = $derived(event?.tags?.filter(([k]) => k === 't').map(([_, v]) => v) || []);
@@ -469,10 +471,10 @@
     }
   });
 
-  // Lazy-load history revisions (History tab)
+  // Load history revisions in background (after main article load) to update versions count dynamically
   let historyLoaded = false;
   $effect(() => {
-    if (activeTab === 'history' && readRelays.length > 0 && event && !historyLoaded) {
+    if (readRelays.length > 0 && event && !historyLoaded) {
       historyLoaded = true;
       const sub = pool.subscribeMany(
         readRelays,
@@ -518,13 +520,7 @@
     return () => clearTimeout(to);
   });
 
-  onMount(() => {
-    // preemptively load other versions if necessary
-    if (articleCard.versions) {
-      nOthers = articleCard.versions.length;
-      return;
-    }
-  });
+
 
   let cancelers: Array<() => void> = [];
   onDestroy(() => {

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy, onMount, untrack } from 'svelte';
   import type { EventTemplate, NostrEvent } from '@nostr/tools/pure';
   import { pool } from '@nostr/gadgets/global';
   import { loadRelayList } from '@nostr/gadgets/lists';
@@ -35,41 +35,45 @@
 
   $effect(() => {
     if (event) {
-      try {
-        const stored = localStorage.getItem('wikistr:pinned');
-        const pinned = stored ? JSON.parse(stored) : [];
-        if (Array.isArray(pinned)) {
-          isPinned = pinned.some((x: any) => x.dTag === dTag && x.pubkey === pubkey);
+      untrack(() => {
+        try {
+          const stored = localStorage.getItem('wikistr:pinned');
+          const pinned = stored ? JSON.parse(stored) : [];
+          if (Array.isArray(pinned)) {
+            isPinned = pinned.some((x: any) => x.dTag === dTag && x.pubkey === pubkey);
+          }
+        } catch (e) {
+          console.error(e);
         }
-      } catch (e) {
-        console.error(e);
-      }
+      });
     }
   });
 
   $effect(() => {
     if (event) {
-      try {
-        const stored = localStorage.getItem('wikistr:history');
-        let history = stored ? JSON.parse(stored) : [];
-        if (!Array.isArray(history)) history = [];
-        
-        const historyItem = {
-          dTag,
-          pubkey,
-          title: title || dTag,
-          timestamp: Date.now()
-        };
-        
-        history = history.filter((x: any) => !(x.dTag === dTag && x.pubkey === pubkey));
-        history.unshift(historyItem);
-        history = history.slice(0, 5);
-        
-        localStorage.setItem('wikistr:history', JSON.stringify(history));
-        window.dispatchEvent(new Event('wikistr:dashboard-update'));
-      } catch (e) {
-        console.error('Failed to update history', e);
-      }
+      untrack(() => {
+        try {
+          const stored = localStorage.getItem('wikistr:history');
+          let history = stored ? JSON.parse(stored) : [];
+          if (!Array.isArray(history)) history = [];
+          
+          const historyItem = {
+            dTag,
+            pubkey,
+            title: title || dTag,
+            timestamp: Date.now()
+          };
+          
+          history = history.filter((x: any) => !(x.dTag === dTag && x.pubkey === pubkey));
+          history.unshift(historyItem);
+          history = history.slice(0, 5);
+          
+          localStorage.setItem('wikistr:history', JSON.stringify(history));
+          window.dispatchEvent(new Event('wikistr:dashboard-update'));
+        } catch (e) {
+          console.error('Failed to update history', e);
+        }
+      });
     }
   });
 
@@ -320,6 +324,8 @@
   function seeOthers(ev: MouseEvent) {
     if (
       articleCard.back &&
+      'data' in articleCard.back &&
+      typeof articleCard.back.data === 'string' &&
       event &&
       normalizeIdentifier(articleCard.back.data) === getTagOr(event, 'd')
     ) {

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -65,6 +65,7 @@
         history = history.slice(0, 5);
         
         localStorage.setItem('wikistr:history', JSON.stringify(history));
+        window.dispatchEvent(new Event('wikistr:dashboard-update'));
       } catch (e) {
         console.error('Failed to update history', e);
       }
@@ -86,6 +87,7 @@
         pinned = pinned.filter((x: any) => !(x.dTag === dTag && x.pubkey === pubkey));
       }
       localStorage.setItem('wikistr:pinned', JSON.stringify(pinned));
+      window.dispatchEvent(new Event('wikistr:dashboard-update'));
     } catch (e) {
       console.error(e);
     }

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -751,7 +751,7 @@
 
       <!-- Table of Contents -->
       {#if headings.length > 0}
-        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 w-full">
+        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 w-full max-w-none" style="width: 100% !important; max-width: none !important;">
           <div class="text-xs font-bold text-stone-700 uppercase tracking-wider mb-2 border-b border-stone-200 pb-1 flex justify-between items-center">
             <span>Table of Contents</span>
           </div>

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -227,6 +227,7 @@
 
   let title = $derived(event?.tags?.find?.(([k]) => k === 'title')?.[1] || dTag);
   let summary = $derived(event?.tags?.find(([k]) => k === 'summary')?.[1]);
+  let tagsList = $derived(event?.tags?.filter(([k]) => k === 't').map(([_, v]) => v) || []);
   let rawEvent = $derived(event ? JSON.stringify(event, null, 2) : '{...}');
 
   function edit() {
@@ -237,9 +238,10 @@
         title,
         summary: summary || '',
         content: event?.content || '',
+        tags: tagsList,
         previous: card as ArticleCard
       }
-    });
+    } as any);
   }
 
   function shareCopy() {
@@ -589,6 +591,18 @@
             {formatDate(event.created_at)}
           {/if}
         </div>
+        {#if tagsList.length > 0}
+          <div class="flex flex-wrap gap-1.5 mt-2">
+            {#each tagsList as tag}
+              <button 
+                onclick={() => createChild({ id: next(), type: 'find', data: '#' + tag, preferredAuthors: [] })}
+                class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-stone-100 text-stone-600 border border-stone-200 hover:bg-stone-200 hover:text-stone-800 transition-colors"
+              >
+                #{tag}
+              </button>
+            {/each}
+          </div>
+        {/if}
         <div>
           <a class="cursor-pointer underline" onclick={edit}>
             {#if event?.pubkey === $account?.pubkey}

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -52,20 +52,33 @@
     if (!event?.content) return [];
     const lines = event.content.split(/\r?\n/);
     const list: Heading[] = [];
+    
+    const hasAsciiDocHeadings = lines.some(line => line.match(/^={2,6}\s+.+$/));
+    let inCodeBlock = false;
+
     lines.forEach((line) => {
-      const adMatch = line.match(/^(=+)\s+(.+)$/);
-      if (adMatch) {
-        const level = adMatch[1].length;
-        if (level > 1) {
-          list.push({ title: adMatch[2].trim(), level });
-        }
+      const trimmed = line.trim();
+      if (trimmed.startsWith('----') || trimmed.startsWith('....') || trimmed.startsWith('```')) {
+        inCodeBlock = !inCodeBlock;
         return;
       }
-      const mdMatch = line.match(/^(#+)\s+(.+)$/);
-      if (mdMatch) {
-        const level = mdMatch[1].length;
-        if (level > 1) {
-          list.push({ title: mdMatch[2].trim(), level });
+      if (inCodeBlock) return;
+
+      if (hasAsciiDocHeadings) {
+        const adMatch = line.match(/^(=+)\s+(.+)$/);
+        if (adMatch) {
+          const level = adMatch[1].length;
+          if (level > 1) {
+            list.push({ title: adMatch[2].trim(), level });
+          }
+        }
+      } else {
+        const mdMatch = line.match(/^(#+)\s+(.+)$/);
+        if (mdMatch) {
+          const level = mdMatch[1].length;
+          if (level > 1) {
+            list.push({ title: mdMatch[2].trim(), level });
+          }
         }
       }
     });

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -14,6 +14,7 @@
   import ArticleContent from '$components/ArticleContent.svelte';
   import RelayItem from '$components/RelayItem.svelte';
   import { diffLines } from '$lib/diff';
+  import { publishPrivateTagsToRelays } from '$lib/privateTagsSync';
 
   interface Props {
     card: Card;
@@ -127,6 +128,9 @@
         localStorage.setItem('wikistr:private-tags', JSON.stringify(allPrivateTags));
         privateTags = existing;
         window.dispatchEvent(new Event('wikistr:dashboard-update'));
+        if ($account) {
+          publishPrivateTagsToRelays($account.pubkey);
+        }
       }
     } catch (e) {
       console.error(e);
@@ -144,6 +148,9 @@
       localStorage.setItem('wikistr:private-tags', JSON.stringify(allPrivateTags));
       privateTags = existing;
       window.dispatchEvent(new Event('wikistr:dashboard-update'));
+      if ($account) {
+        publishPrivateTagsToRelays($account.pubkey);
+      }
     } catch (e) {
       console.error(e);
     }

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -7,12 +7,13 @@
   import { naddrEncode } from '@nostr/tools/nip19';
   import { normalizeIdentifier } from '@nostr/tools/nip54';
 
-  import { account, reactionKind, wikiKind, signer } from '$lib/nostr';
+  import { account, reactionKind, wikiKind, gitPatchKind, signer } from '$lib/nostr';
   import { formatDate, getA, getTagOr, next } from '$lib/utils';
   import type { ArticleCard, SearchCard, Card } from '$lib/types';
   import UserLabel from '$components/UserLabel.svelte';
   import ArticleContent from '$components/ArticleContent.svelte';
   import RelayItem from '$components/RelayItem.svelte';
+  import { diffLines } from '$lib/diff';
 
   interface Props {
     card: Card;
@@ -23,6 +24,10 @@
 
   let { card, createChild, replaceSelf, back }: Props = $props();
   let event = $state<NostrEvent | null>(null);
+  let suggestions = $state<NostrEvent[]>([]);
+  let showSuggestionsPanel = $state(false);
+  let selectedSuggestion = $state<NostrEvent | null>(null);
+  let merging = $state(false);
   let nOthers = $state<number | undefined>(undefined);
   let copied = $state(false);
   let likeStatus: 'liked' | 'disliked' | unknown;
@@ -46,9 +51,9 @@
       type: 'editor',
       data: {
         title,
-        summary,
-        content: event?.content,
-        previous: card
+        summary: summary || '',
+        content: event?.content || '',
+        previous: card as ArticleCard
       }
     });
   }
@@ -124,6 +129,30 @@
             if (!event || event.created_at < evt.created_at) {
               event = evt;
               setupLikes();
+            }
+          }
+        }
+      );
+    })();
+
+    (async () => {
+      let relays = await loadRelayList(pubkey);
+      pool.subscribeMany(
+        relays.items
+          .filter((ri) => ri.read)
+          .map((ri) => ri.url)
+          .concat((card as ArticleCard).relayHints || []),
+        [
+          {
+            kinds: [gitPatchKind],
+            '#a': [`${wikiKind}:${pubkey}:${dTag}`]
+          }
+        ],
+        {
+          id: 'suggestions-' + dTag,
+          onevent(evt) {
+            if (!suggestions.some((s) => s.id === evt.id)) {
+              suggestions = [...suggestions, evt].sort((a, b) => b.created_at - a.created_at);
             }
           }
         }
@@ -306,7 +335,7 @@
             {#if event?.pubkey === $account?.pubkey}
               Edit
             {:else}
-              Fork
+              Fork / Suggest Edit
             {/if}
           </a>
           &nbsp;• &nbsp;
@@ -315,9 +344,170 @@
           </a>
           &nbsp;• &nbsp;
           <a class="cursor-pointer underline" onmouseup={seeOthers}>{nOthers || ''} Versions</a>
+          {#if suggestions.length > 0}
+            &nbsp;• &nbsp;
+            <a class="cursor-pointer underline text-emerald-600 hover:text-emerald-700 font-semibold" onclick={() => showSuggestionsPanel = !showSuggestionsPanel}>
+              {suggestions.length} Suggestion{suggestions.length > 1 ? 's' : ''}
+            </a>
+          {/if}
         </div>
       </div>
     </div>
+
+    <!-- Suggestions Panel -->
+    {#if showSuggestionsPanel}
+      <div class="mt-2 mb-4 p-4 border border-emerald-200 rounded-lg bg-emerald-50/30">
+        <div class="flex justify-between items-center mb-3">
+          <h3 class="font-bold text-lg text-emerald-800">Suggestions (Pull Requests)</h3>
+          <button 
+            onclick={() => { showSuggestionsPanel = false; selectedSuggestion = null; }}
+            class="text-xs text-stone-500 hover:text-stone-700 bg-white border border-stone-200 px-2 py-0.5 rounded shadow-sm"
+          >
+            Hide
+          </button>
+        </div>
+
+        {#if !selectedSuggestion}
+          {#if suggestions.length === 0}
+            <p class="text-stone-500 text-sm">No suggestions yet.</p>
+          {:else}
+            <div class="space-y-2">
+              {#each suggestions as sug (sug.id)}
+                <div class="p-3 bg-white border border-stone-200 rounded shadow-sm hover:border-emerald-500 transition-colors flex justify-between items-start">
+                  <div>
+                    <div class="font-semibold text-stone-900 text-sm">
+                      {getTagOr(sug, 'title') || 'Proposed Edit'}
+                    </div>
+                    <div class="text-xs text-stone-500 mt-1">
+                      by <UserLabel pubkey={sug.pubkey} {createChild} /> {formatDate(sug.created_at)}
+                    </div>
+                    {#if getTagOr(sug, 'summary')}
+                      <div class="text-xs text-stone-600 mt-1 bg-stone-50 p-1.5 rounded italic">
+                        "{getTagOr(sug, 'summary')}"
+                      </div>
+                    {/if}
+                  </div>
+                  <button
+                    onclick={() => selectedSuggestion = sug}
+                    class="ml-4 px-2.5 py-1 bg-emerald-600 text-white rounded text-xs hover:bg-emerald-700 font-semibold"
+                  >
+                    Review Diff
+                  </button>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        {:else}
+          <!-- Reviewing a specific suggestion -->
+          <div class="bg-white border border-emerald-100 rounded p-3 shadow-sm">
+            <div class="flex justify-between items-center mb-3 border-b border-stone-100 pb-1.5">
+              <div>
+                <div class="text-xs text-stone-500">Reviewing suggestion from:</div>
+                <div class="font-medium text-xs flex items-center gap-1">
+                  <UserLabel pubkey={selectedSuggestion.pubkey} {createChild} />
+                  <span class="text-[10px] text-stone-400">({formatDate(selectedSuggestion.created_at)})</span>
+                </div>
+              </div>
+              <button 
+                onclick={() => selectedSuggestion = null}
+                class="text-xs text-indigo-600 hover:text-indigo-850 font-medium"
+              >
+                ← Back
+              </button>
+            </div>
+
+            <!-- Diff Viewer -->
+            <div class="mt-2 border border-stone-200 rounded overflow-hidden font-mono text-xs max-h-72 overflow-y-auto bg-stone-50">
+              {#each diffLines(event?.content || '', selectedSuggestion.content) as line, idx}
+                <div class="flex select-text {line.type === 'added' ? 'bg-emerald-50 text-emerald-900' : ''} {line.type === 'removed' ? 'bg-rose-50 text-rose-900' : ''}">
+                  <div class="w-10 text-right text-stone-400 select-none border-r border-stone-200/50 pr-1.5 mr-1.5 bg-stone-100/50 text-[10px] py-0.5">
+                    {idx + 1}
+                  </div>
+                  <div class="w-4 select-none text-center font-bold" class:text-emerald-600={line.type === 'added'} class:text-rose-600={line.type === 'removed'}>
+                    {#if line.type === 'added'}+{/if}
+                    {#if line.type === 'removed'}-{/if}
+                    {#if line.type === 'unmodified'}&nbsp;{/if}
+                  </div>
+                  <div class="whitespace-pre-wrap py-0.5 break-all flex-1">{line.value}</div>
+                </div>
+              {/each}
+            </div>
+
+            <!-- Merge/Approve Actions -->
+            <div class="mt-3 flex justify-end space-x-2 border-t border-stone-100 pt-2">
+              {#if $account?.pubkey === event?.pubkey}
+                <button
+                  onclick={async () => {
+                    if (!selectedSuggestion || !event) return;
+                    merging = true;
+                    try {
+                      let eventTemplate: EventTemplate = {
+                        kind: wikiKind,
+                        tags: [
+                          ['d', getTagOr(event, 'd')],
+                          ['contributor', selectedSuggestion.pubkey]
+                        ],
+                        content: selectedSuggestion.content.trim(),
+                        created_at: Math.round(Date.now() / 1000)
+                      };
+
+                      const propTitle = getTagOr(selectedSuggestion, 'title') || getTagOr(event, 'title');
+                      if (propTitle && propTitle !== getTagOr(event, 'd')) {
+                        eventTemplate.tags.push(['title', propTitle]);
+                      }
+                      const propSummary = getTagOr(selectedSuggestion, 'summary') || getTagOr(event, 'summary');
+                      if (propSummary) {
+                        eventTemplate.tags.push(['summary', propSummary]);
+                      }
+
+                      let signed = await signer.signEvent(eventTemplate);
+                      let successes: string[] = [];
+                      await Promise.all(
+                        seenOn.map(async (url) => {
+                          try {
+                            const r = await pool.ensureRelay(url);
+                            await r.publish(signed);
+                            successes.push(url);
+                          } catch (err) {
+                            console.warn('Failed publishing merged event to', url, err);
+                          }
+                        })
+                      );
+
+                      if (successes.length) {
+                        event = signed;
+                        suggestions = suggestions.filter((s) => s.id !== selectedSuggestion!.id);
+                        selectedSuggestion = null;
+                        showSuggestionsPanel = false;
+                      }
+                    } catch (err) {
+                      alert('Error merging suggestion: ' + err);
+                    } finally {
+                      merging = false;
+                    }
+                  }}
+                  disabled={merging}
+                  class="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-white rounded font-semibold text-xs disabled:opacity-50"
+                >
+                  {#if merging}Merging...{:else}Accept & Merge{/if}
+                </button>
+              {/if}
+              <button
+                onclick={() => {
+                  if (selectedSuggestion) {
+                    suggestions = suggestions.filter((s) => s.id !== selectedSuggestion!.id);
+                    selectedSuggestion = null;
+                  }
+                }}
+                class="px-3 py-1.5 bg-stone-100 hover:bg-stone-200 text-stone-700 rounded font-semibold text-xs"
+              >
+                Ignore Suggestion
+              </button>
+            </div>
+          </div>
+        {/if}
+      </div>
+    {/if}
 
     <!-- Content -->
     {#if view === 'raw'}

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -282,11 +282,17 @@
     }
   }
 
-  const articleCard = card as ArticleCard;
-  const dTag = articleCard.data[0];
-  const pubkey = articleCard.data[1];
+  let articleCard = $derived(card as ArticleCard);
+  let dTag = $derived(articleCard.data[0]);
+  let pubkey = $derived(articleCard.data[1]);
+  let author = $state<NostrUser>(bareNostrUser(''));
 
-  let author = $state<NostrUser>(bareNostrUser(pubkey));
+  $effect(() => {
+    author = bareNostrUser(pubkey);
+    loadNostrUser(pubkey).then((user) => {
+      author = user;
+    });
+  });
 
   let loadedRelays = $state<any>(null);
   let readRelays = $derived(loadedRelays ? loadedRelays.items.filter((ri: any) => ri.read).map((ri: any) => ri.url).concat(articleCard.relayHints || []) : []);
@@ -325,6 +331,10 @@
         previous: prevCard
       }
     } as any);
+  }
+
+  function selectOnMount(node: HTMLInputElement) {
+    node.focus();
   }
 
   function shareCopy() {
@@ -399,10 +409,6 @@
         }
       });
     }
-
-    loadNostrUser(pubkey).then((user) => {
-      author = user;
-    });
   });
 
   // Subscribe to the main article
@@ -750,7 +756,7 @@
                 bind:value={newPrivateTag} 
                 placeholder="private tag"
                 class="px-2 py-0.5 text-xs border border-stone-300 rounded focus:ring-1 focus:ring-amber-500 focus:outline-none w-24"
-                autoFocus
+                use:selectOnMount
                 onblur={() => {
                   setTimeout(() => {
                     if (!newPrivateTag) showAddPrivateTag = false;
@@ -1029,13 +1035,13 @@
           <ul class="space-y-1.5 text-sm">
             {#each headings as heading}
               <li style:padding-left={`${(heading.level - minHeadingLevel) * 12}px`}>
-                <a
-                  href="javascript:void(0)"
+                <button
+                  type="button"
                   onclick={() => scrollToHeading(heading.title)}
-                  class="text-indigo-600 hover:text-indigo-850 hover:underline inline-block break-all"
+                  class="text-indigo-600 hover:text-indigo-850 hover:underline inline-block break-all text-left bg-transparent border-0 p-0 cursor-pointer font-normal"
                 >
                   {heading.title}
-                </a>
+                </button>
               </li>
             {/each}
           </ul>
@@ -1066,8 +1072,8 @@
             <ul class="mt-2 text-xs space-y-1 pl-5 list-disc text-indigo-600">
               {#each backlinks as link (link.id)}
                 <li>
-                  <a
-                    href="javascript:void(0)"
+                  <button
+                    type="button"
                     onclick={() => {
                       createChild({
                         id: next(),
@@ -1076,10 +1082,10 @@
                         actualEvent: link
                       } as ArticleCard);
                     }}
-                    class="hover:underline"
+                    class="hover:underline text-left bg-transparent border-0 p-0 cursor-pointer font-normal text-indigo-600 inline-block break-all"
                   >
                     {getTagOr(link, 'title') || getTagOr(link, 'd')}
-                  </a>
+                  </button>
                   <span class="text-stone-400">by <UserLabel pubkey={link.pubkey} {createChild} /></span>
                 </li>
               {/each}

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -751,7 +751,7 @@
 
       <!-- Table of Contents -->
       {#if headings.length > 0}
-        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 w-full max-w-full sm:max-w-md lg:max-w-lg">
+        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 w-full">
           <div class="text-xs font-bold text-stone-700 uppercase tracking-wider mb-2 border-b border-stone-200 pb-1 flex justify-between items-center">
             <span>Table of Contents</span>
           </div>

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -8,7 +8,7 @@
   import { normalizeIdentifier } from '@nostr/tools/nip54';
 
   import { account, reactionKind, wikiKind, gitPatchKind, signer } from '$lib/nostr';
-  import { formatDate, getA, getTagOr, next } from '$lib/utils';
+  import { formatDate, getA, getTagOr, next, unique } from '$lib/utils';
   import type { ArticleCard, SearchCard, Card } from '$lib/types';
   import UserLabel from '$components/UserLabel.svelte';
   import ArticleContent from '$components/ArticleContent.svelte';
@@ -34,6 +34,89 @@
   let canLike = $state<boolean | undefined>();
   let seenOn = $state<string[]>([]);
   let view = $state<'formatted' | 'asciidoc' | 'raw'>('formatted');
+
+  // Wiki features state
+  let activeTab = $state<'article' | 'discussion' | 'history'>('article');
+  let comments = $state<NostrEvent[]>([]);
+  let newCommentText = $state('');
+  let publishingComment = $state(false);
+  let historyEvents = $state<NostrEvent[]>([]);
+  let backlinks = $state<NostrEvent[]>([]);
+
+  interface Heading {
+    title: string;
+    level: number;
+  }
+
+  let headings = $derived.by<Heading[]>(() => {
+    if (!event?.content) return [];
+    const lines = event.content.split(/\r?\n/);
+    const list: Heading[] = [];
+    lines.forEach((line) => {
+      const adMatch = line.match(/^(=+)\s+(.+)$/);
+      if (adMatch) {
+        list.push({ title: adMatch[2].trim(), level: adMatch[1].length });
+        return;
+      }
+      const mdMatch = line.match(/^(#+)\s+(.+)$/);
+      if (mdMatch) {
+        list.push({ title: mdMatch[2].trim(), level: mdMatch[1].length });
+      }
+    });
+    return list;
+  });
+
+  function scrollToHeading(headingTitle: string) {
+    const cardEl = document.getElementById(`wikicard-${card.id}`);
+    if (!cardEl) return;
+    const elements = cardEl.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    for (const el of Array.from(elements)) {
+      if (el.textContent?.trim().toLowerCase() === headingTitle.toLowerCase()) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        break;
+      }
+    }
+  }
+
+  async function publishComment() {
+    if (!newCommentText.trim() || !event) return;
+    publishingComment = true;
+    try {
+      const commentTemplate: EventTemplate = {
+        kind: 1111,
+        tags: [
+          ['a', `${wikiKind}:${pubkey}:${dTag}`, seenOn[0] || ''],
+          ['e', event.id, seenOn[0] || '']
+        ],
+        content: newCommentText.trim(),
+        created_at: Math.round(Date.now() / 1000)
+      };
+
+      const signed = await signer.signEvent(commentTemplate);
+      const relays = unique(
+        (await loadRelayList($account!.pubkey)).items.filter((ri) => ri.write).map((ri) => ri.url),
+        seenOn
+      );
+
+      await Promise.all(
+        relays.map(async (url: string) => {
+          try {
+            const r = await pool.ensureRelay(url);
+            await r.publish(signed);
+          } catch (err) {
+            console.warn('Failed publishing comment to', url, err);
+          }
+        })
+      );
+
+      comments = [...comments, signed].sort((a, b) => a.created_at - b.created_at);
+      newCommentText = '';
+    } catch (err) {
+      alert('Failed to publish comment: ' + err);
+    } finally {
+      publishingComment = false;
+    }
+  }
 
   const articleCard = card as ArticleCard;
   const dTag = articleCard.data[0];
@@ -153,6 +236,81 @@
           onevent(evt) {
             if (!suggestions.some((s) => s.id === evt.id)) {
               suggestions = [...suggestions, evt].sort((a, b) => b.created_at - a.created_at);
+            }
+          }
+        }
+      );
+    })();
+
+    // load comments
+    (async () => {
+      let relays = await loadRelayList(pubkey);
+      pool.subscribeMany(
+        relays.items
+          .filter((ri) => ri.read)
+          .map((ri) => ri.url)
+          .concat((card as ArticleCard).relayHints || []),
+        [
+          {
+            kinds: [1, 1111],
+            '#a': [`${wikiKind}:${pubkey}:${dTag}`]
+          }
+        ],
+        {
+          id: 'comments-' + dTag,
+          onevent(evt) {
+            if (!comments.some((c) => c.id === evt.id)) {
+              comments = [...comments, evt].sort((a, b) => a.created_at - b.created_at);
+            }
+          }
+        }
+      );
+    })();
+
+    // load history revisions
+    (async () => {
+      let relays = await loadRelayList(pubkey);
+      pool.subscribeMany(
+        relays.items
+          .filter((ri) => ri.read)
+          .map((ri) => ri.url)
+          .concat((card as ArticleCard).relayHints || []),
+        [
+          {
+            kinds: [wikiKind],
+            '#d': [dTag]
+          }
+        ],
+        {
+          id: 'history-' + dTag,
+          onevent(evt) {
+            if (!historyEvents.some((h) => h.id === evt.id)) {
+              historyEvents = [...historyEvents, evt].sort((a, b) => b.created_at - a.created_at);
+            }
+          }
+        }
+      );
+    })();
+
+    // load backlinks
+    (async () => {
+      let relays = await loadRelayList(pubkey);
+      pool.subscribeMany(
+        relays.items
+          .filter((ri) => ri.read)
+          .map((ri) => ri.url)
+          .concat((card as ArticleCard).relayHints || []),
+        [
+          {
+            kinds: [wikiKind],
+            '#a': [`${wikiKind}:${pubkey}:${dTag}`]
+          }
+        ],
+        {
+          id: 'backlinks-' + dTag,
+          onevent(evt) {
+            if (!backlinks.some((b) => b.id === evt.id)) {
+              backlinks = [...backlinks, evt];
             }
           }
         }
@@ -509,14 +667,223 @@
       </div>
     {/if}
 
-    <!-- Content -->
-    {#if view === 'raw'}
-      <div class="font-mono whitespace-pre-wrap">{rawEvent}</div>
-    {:else if view === 'asciidoc'}
-      <div class="prose whitespace-pre-wrap">{event.content}</div>
-    {:else if view === 'formatted'}
-      <div class="prose prose-p:my-0 prose-li:my-0">
-        <ArticleContent {event} {createChild} />
+    <!-- Tabs Header -->
+    <div class="mt-4 border-b border-stone-250 flex items-center space-x-4">
+      <button
+        onclick={() => activeTab = 'article'}
+        class="pb-2 text-sm font-bold border-b-2 transition-colors focus:outline-none"
+        class:border-indigo-600={activeTab === 'article'}
+        class:text-indigo-600={activeTab === 'article'}
+        class:border-transparent={activeTab !== 'article'}
+        class:text-stone-500={activeTab !== 'article'}
+      >
+        Article
+      </button>
+      <button
+        onclick={() => activeTab = 'discussion'}
+        class="pb-2 text-sm font-bold border-b-2 transition-colors focus:outline-none flex items-center gap-1.5"
+        class:border-indigo-600={activeTab === 'discussion'}
+        class:text-indigo-600={activeTab === 'discussion'}
+        class:border-transparent={activeTab !== 'discussion'}
+        class:text-stone-500={activeTab !== 'discussion'}
+      >
+        Discussion
+        {#if comments.length > 0}
+          <span class="bg-stone-200 text-stone-700 px-1.5 py-0.5 rounded-full text-[10px]">
+            {comments.length}
+          </span>
+        {/if}
+      </button>
+      <button
+        onclick={() => activeTab = 'history'}
+        class="pb-2 text-sm font-bold border-b-2 transition-colors focus:outline-none"
+        class:border-indigo-600={activeTab === 'history'}
+        class:text-indigo-600={activeTab === 'history'}
+        class:border-transparent={activeTab !== 'history'}
+        class:text-stone-500={activeTab !== 'history'}
+      >
+        History
+      </button>
+    </div>
+
+    <!-- Tab Contents -->
+    {#if activeTab === 'article'}
+      <!-- Info / Metadata Box (Wiki Sidebar) -->
+      <div class="mt-4 p-3 bg-stone-50 border border-stone-200 rounded shadow-sm flex flex-col md:flex-row justify-between text-xs text-stone-600 gap-2 mb-4">
+        <div>
+          <span class="font-semibold text-stone-700">Page size:</span>
+          {event.content.length} characters ({Math.round(event.content.length / 10.24) / 100} KB)
+        </div>
+        <div>
+          <span class="font-semibold text-stone-700">Revisions:</span>
+          {historyEvents.filter(h => h.pubkey === event?.pubkey).length || 1}
+        </div>
+        <div>
+          <span class="font-semibold text-stone-700">Contributors:</span>
+          {unique(historyEvents.map(h => h.pubkey)).length || 1}
+        </div>
+        <div>
+          <span class="font-semibold text-stone-700">First published:</span>
+          {#if historyEvents.length > 0}
+            {formatDate(historyEvents[historyEvents.length - 1].created_at)}
+          {:else}
+            {formatDate(event.created_at)}
+          {/if}
+        </div>
+      </div>
+
+      <!-- Table of Contents -->
+      {#if headings.length > 0}
+        <div class="mt-2 mb-6 p-4 border border-stone-200 rounded-md bg-stone-50/50 max-w-sm">
+          <div class="text-xs font-bold text-stone-700 uppercase tracking-wider mb-2 border-b border-stone-200 pb-1 flex justify-between items-center">
+            <span>Table of Contents</span>
+          </div>
+          <ul class="space-y-1.5 text-sm">
+            {#each headings as heading}
+              <li style:padding-left={`${(heading.level - 1) * 12}px`}>
+                <a
+                  href="javascript:void(0)"
+                  onclick={() => scrollToHeading(heading.title)}
+                  class="text-indigo-600 hover:text-indigo-850 hover:underline inline-block break-all"
+                >
+                  {heading.title}
+                </a>
+              </li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+
+      <!-- Main Article Content -->
+      {#if view === 'raw'}
+        <div class="font-mono whitespace-pre-wrap text-sm border border-stone-200 p-3 bg-stone-50 rounded">{rawEvent}</div>
+      {:else if view === 'asciidoc'}
+        <div class="prose whitespace-pre-wrap text-sm border border-stone-200 p-3 bg-stone-50 rounded">{event.content}</div>
+      {:else if view === 'formatted'}
+        <div class="prose prose-p:my-0 prose-li:my-0">
+          <ArticleContent {event} {createChild} />
+        </div>
+      {/if}
+
+      <!-- Backlinks section ("What links here") -->
+      <div class="mt-8 border-t border-stone-250 pt-4">
+        <details class="group">
+          <summary class="cursor-pointer text-xs font-semibold text-stone-500 hover:text-stone-850 focus:outline-none flex items-center select-none">
+            <svg class="w-3.5 h-3.5 mr-1 transform group-open:rotate-90 transition-transform stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" /></svg>
+            What links here ({backlinks.length})
+          </summary>
+          {#if backlinks.length === 0}
+            <div class="mt-2 text-xs text-stone-400 italic pl-5">No other articles link to this article yet.</div>
+          {:else}
+            <ul class="mt-2 text-xs space-y-1 pl-5 list-disc text-indigo-600">
+              {#each backlinks as link (link.id)}
+                <li>
+                  <a
+                    href="javascript:void(0)"
+                    onclick={() => {
+                      createChild({
+                        id: next(),
+                        type: 'article',
+                        data: [getTagOr(link, 'd'), link.pubkey],
+                        actualEvent: link
+                      } as ArticleCard);
+                    }}
+                    class="hover:underline"
+                  >
+                    {getTagOr(link, 'title') || getTagOr(link, 'd')}
+                  </a>
+                  <span class="text-stone-400">by <UserLabel pubkey={link.pubkey} {createChild} /></span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </details>
+      </div>
+
+    {:else if activeTab === 'discussion'}
+      <!-- Comments / Discussion -->
+      <div class="mt-4 space-y-3">
+        {#if comments.length === 0}
+          <div class="text-center py-6 text-stone-400 text-sm italic">
+            No discussion on this article yet. Be the first to start the talk page!
+          </div>
+        {:else}
+          {#each comments as comm (comm.id)}
+            <div class="p-3 bg-stone-50 border border-stone-200 rounded shadow-sm">
+              <div class="flex justify-between items-center border-b border-stone-200/50 pb-1 mb-2 text-xs">
+                <span class="font-semibold text-stone-700">
+                  <UserLabel pubkey={comm.pubkey} {createChild} />
+                </span>
+                <span class="text-stone-400">
+                  {formatDate(comm.created_at)}
+                </span>
+              </div>
+              <div class="text-stone-800 text-sm whitespace-pre-wrap select-text">{comm.content}</div>
+            </div>
+          {/each}
+        {/if}
+
+        <!-- Post a Comment -->
+        {#if $account}
+          <div class="mt-6 border-t border-stone-200 pt-4">
+            <h4 class="text-sm font-semibold text-stone-700 mb-2">Add to the discussion:</h4>
+            <textarea
+              bind:value={newCommentText}
+              placeholder="Provide constructive feedback, propose edits, or ask questions about the article..."
+              class="w-full h-24 p-2 text-sm border border-stone-300 rounded focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+              disabled={publishingComment}
+            ></textarea>
+            <div class="mt-2 flex justify-end">
+              <button
+                onclick={publishComment}
+                disabled={publishingComment || !newCommentText.trim()}
+                class="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-xs rounded shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+              >
+                {#if publishingComment}Publishing...{:else}Post Comment{/if}
+              </button>
+            </div>
+          </div>
+        {:else}
+          <div class="mt-6 border-t border-stone-200 pt-4 text-center text-xs text-stone-500 italic">
+            Please log in with a Nostr extension to participate in the discussion.
+          </div>
+        {/if}
+      </div>
+
+    {:else if activeTab === 'history'}
+      <!-- History Revisions -->
+      <div class="mt-4 space-y-2">
+        <h4 class="text-sm font-semibold text-stone-700 mb-3">Revision History:</h4>
+        {#if historyEvents.length === 0}
+          <div class="text-xs text-stone-400 italic">Loading revision history...</div>
+        {:else}
+          <div class="border border-stone-200 rounded divide-y divide-stone-200">
+            {#each historyEvents as rev}
+              <div class="p-3 bg-white hover:bg-stone-50 flex justify-between items-center text-xs">
+                <div>
+                  <span class="font-mono text-[10px] bg-stone-100 text-stone-600 px-1.5 py-0.5 rounded mr-2">
+                    {rev.id.substring(0, 8)}
+                  </span>
+                  <span class="text-stone-500 font-semibold">{formatDate(rev.created_at)}</span>
+                  <span class="text-stone-400 mx-1.5">•</span>
+                  <span>by <UserLabel pubkey={rev.pubkey} {createChild} /></span>
+                  {#if getTagOr(rev, 'summary')}
+                    <span class="text-stone-400 block mt-1 italic">"{getTagOr(rev, 'summary')}"</span>
+                  {/if}
+                </div>
+                <button
+                  onclick={() => {
+                    event = rev;
+                    activeTab = 'article';
+                  }}
+                  class="px-2 py-0.5 border border-stone-300 rounded bg-stone-50 hover:bg-stone-100 font-semibold"
+                >
+                  View Revision
+                </button>
+              </div>
+            {/each}
+          </div>
+        {/if}
       </div>
     {/if}
 

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -287,6 +287,10 @@
 
   let author = $state<NostrUser>(bareNostrUser(pubkey));
 
+  let loadedRelays = $state<any>(null);
+  let readRelays = $derived(loadedRelays ? loadedRelays.items.filter((ri: any) => ri.read).map((ri: any) => ri.url).concat(articleCard.relayHints || []) : []);
+  let writeRelays = $derived(loadedRelays ? loadedRelays.items.filter((ri: any) => ri.write).map((ri: any) => ri.url).concat(articleCard.relayHints || []) : []);
+
   let title = $derived(event?.tags?.find?.(([k]) => k === 'title')?.[1] || dTag);
   let summary = $derived(event?.tags?.find(([k]) => k === 'summary')?.[1]);
   let tagsList = $derived(event?.tags?.filter(([k]) => k === 't').map(([_, v]) => v) || []);
@@ -346,21 +350,27 @@
 
   onMount(() => {
     loadPrivateTags();
-    // load this article
+    
+    // Fetch relay list once and store it
+    loadRelayList(pubkey).then((res) => {
+      loadedRelays = res;
+    });
+
     if (articleCard.actualEvent) {
       event = articleCard.actualEvent;
       seenOn = articleCard.relayHints || [];
-      return;
     }
 
-    (async () => {
-      let relays = await loadRelayList(pubkey);
+    loadNostrUser(pubkey).then((user) => {
+      author = user;
+    });
+  });
 
-      pool.subscribeMany(
-        relays.items
-          .filter((ri) => ri.write)
-          .map((ri) => ri.url)
-          .concat((card as ArticleCard).relayHints || []),
+  // Subscribe to the main article
+  $effect(() => {
+    if (writeRelays.length > 0 && !event) {
+      const sub = pool.subscribeMany(
+        writeRelays,
         [
           {
             authors: [pubkey],
@@ -372,8 +382,7 @@
           id: 'article',
           receivedEvent(relay, _id) {
             if (seenOn.indexOf(relay.url) === -1) {
-              seenOn.push(relay.url);
-              seenOn = seenOn;
+              seenOn = [...seenOn, relay.url];
             }
           },
           onevent(evt) {
@@ -384,15 +393,15 @@
           }
         }
       );
-    })();
+      return () => sub.close();
+    }
+  });
 
-    (async () => {
-      let relays = await loadRelayList(pubkey);
-      pool.subscribeMany(
-        relays.items
-          .filter((ri) => ri.read)
-          .map((ri) => ri.url)
-          .concat((card as ArticleCard).relayHints || []),
+  // Subscribe to suggestions & backlinks once readRelays are loaded (after primary load)
+  $effect(() => {
+    if (readRelays.length > 0 && event) {
+      const suggestionsSub = pool.subscribeMany(
+        readRelays,
         [
           {
             kinds: [gitPatchKind],
@@ -408,66 +417,9 @@
           }
         }
       );
-    })();
 
-    // load comments
-    (async () => {
-      let relays = await loadRelayList(pubkey);
-      pool.subscribeMany(
-        relays.items
-          .filter((ri) => ri.read)
-          .map((ri) => ri.url)
-          .concat((card as ArticleCard).relayHints || []),
-        [
-          {
-            kinds: [1, 1111],
-            '#a': [`${wikiKind}:${pubkey}:${dTag}`]
-          }
-        ],
-        {
-          id: 'comments-' + dTag,
-          onevent(evt) {
-            if (!comments.some((c) => c.id === evt.id)) {
-              comments = [...comments, evt].sort((a, b) => a.created_at - b.created_at);
-            }
-          }
-        }
-      );
-    })();
-
-    // load history revisions
-    (async () => {
-      let relays = await loadRelayList(pubkey);
-      pool.subscribeMany(
-        relays.items
-          .filter((ri) => ri.read)
-          .map((ri) => ri.url)
-          .concat((card as ArticleCard).relayHints || []),
-        [
-          {
-            kinds: [wikiKind],
-            '#d': [dTag]
-          }
-        ],
-        {
-          id: 'history-' + dTag,
-          onevent(evt) {
-            if (!historyEvents.some((h) => h.id === evt.id)) {
-              historyEvents = [...historyEvents, evt].sort((a, b) => b.created_at - a.created_at);
-            }
-          }
-        }
-      );
-    })();
-
-    // load backlinks
-    (async () => {
-      let relays = await loadRelayList(pubkey);
-      pool.subscribeMany(
-        relays.items
-          .filter((ri) => ri.read)
-          .map((ri) => ri.url)
-          .concat((card as ArticleCard).relayHints || []),
+      const backlinksSub = pool.subscribeMany(
+        readRelays,
         [
           {
             kinds: [wikiKind],
@@ -483,11 +435,64 @@
           }
         }
       );
-    })();
 
-    (async () => {
-      author = await loadNostrUser(pubkey);
-    })();
+      return () => {
+        suggestionsSub.close();
+        backlinksSub.close();
+      };
+    }
+  });
+
+  // Lazy-load comments (Discussion tab)
+  let commentsLoaded = false;
+  $effect(() => {
+    if (activeTab === 'discussion' && readRelays.length > 0 && event && !commentsLoaded) {
+      commentsLoaded = true;
+      const sub = pool.subscribeMany(
+        readRelays,
+        [
+          {
+            kinds: [1, 1111],
+            '#a': [`${wikiKind}:${pubkey}:${dTag}`]
+          }
+        ],
+        {
+          id: 'comments-' + dTag,
+          onevent(evt) {
+            if (!comments.some((c) => c.id === evt.id)) {
+              comments = [...comments, evt].sort((a, b) => a.created_at - b.created_at);
+            }
+          }
+        }
+      );
+      return () => sub.close();
+    }
+  });
+
+  // Lazy-load history revisions (History tab)
+  let historyLoaded = false;
+  $effect(() => {
+    if (activeTab === 'history' && readRelays.length > 0 && event && !historyLoaded) {
+      historyLoaded = true;
+      const sub = pool.subscribeMany(
+        readRelays,
+        [
+          {
+            kinds: [wikiKind],
+            '#d': [dTag]
+          }
+        ],
+        {
+          id: 'history-' + dTag,
+          onevent(evt) {
+            if (!historyEvents.some((h) => h.id === evt.id)) {
+              historyEvents = [...historyEvents, evt].sort((a, b) => b.created_at - a.created_at);
+            }
+          }
+        }
+      );
+      return () => sub.close();
+    }
   });
 
   onMount(() => {

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -26,6 +26,9 @@
 
   let { card, createChild, replaceSelf, back }: Props = $props();
   let event = $state<NostrEvent | null>(null);
+  let reactionEvents = $state<NostrEvent[]>([]);
+  let hasMarkedAuthoritative = $derived(reactionEvents.some(r => r.pubkey === $account?.pubkey && r.content === '✅'));
+  let authoritativeCount = $derived(reactionEvents.filter(r => r.content === '✅').length);
   let suggestions = $state<NostrEvent[]>([]);
   let showSuggestionsPanel = $state(false);
   let selectedSuggestion = $state<NostrEvent | null>(null);
@@ -551,6 +554,63 @@
     }
   });
 
+  $effect(() => {
+    if (readRelays.length > 0 && event) {
+      const sub = pool.subscribeMany(
+        readRelays,
+        [
+          {
+            kinds: [reactionKind],
+            '#a': [`${wikiKind}:${pubkey}:${dTag}`]
+          }
+        ],
+        {
+          id: 'reactions-' + dTag,
+          onevent(evt) {
+            if (!reactionEvents.some((r) => r.id === evt.id)) {
+              reactionEvents = [...reactionEvents, evt];
+            }
+          }
+        }
+      );
+      return () => sub.close();
+    }
+  });
+
+  async function toggleAuthoritative() {
+    if (!event) return;
+    if (!$account) {
+      alert('Please log in with a Nostr extension to vote.');
+      return;
+    }
+    if (hasMarkedAuthoritative) return;
+
+    let eventTemplate: EventTemplate = {
+      kind: reactionKind,
+      tags: [
+        ['a', `${wikiKind}:${pubkey}:${dTag}`, seenOn[0] || ''],
+        ['e', event.id, seenOn[1] || seenOn[0] || '']
+      ],
+      content: '✅',
+      created_at: Math.round(Date.now() / 1000)
+    };
+
+    try {
+      let reaction = await signer.signEvent(eventTemplate);
+      seenOn.forEach(async (url) => {
+        try {
+          const r = await pool.ensureRelay(url);
+          await r.publish(reaction);
+        } catch (err) {
+          console.warn('failed to publish reaction to', url, err);
+        }
+      });
+      reactionEvents = [...reactionEvents, reaction];
+    } catch (err) {
+      console.warn('Failed to publish reaction', err);
+    }
+  }
+
   onMount(() => {
     // redraw likes thing when we have a logged in user
     return account.subscribe(setupLikes);
@@ -704,7 +764,26 @@
         </div>
       {/if}
       <div class="ml-2 mb-4">
-        <div class="mt-2 font-bold text-4xl">{title || dTag}</div>
+        <div class="mt-2 font-bold text-4xl flex flex-wrap items-center gap-3">
+          <span>{title || dTag}</span>
+          <button
+            type="button"
+            onclick={toggleAuthoritative}
+            class="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-semibold rounded-full border transition-all duration-200 cursor-pointer shadow-sm
+              {hasMarkedAuthoritative 
+                ? 'bg-emerald-100 text-emerald-800 border-emerald-300 hover:bg-emerald-250' 
+                : 'bg-stone-50 text-stone-600 border-stone-250 hover:bg-stone-100 hover:text-stone-800'}"
+            title={hasMarkedAuthoritative ? 'You marked this article as authoritative' : 'Mark this article as authoritative'}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-3.5 h-3.5 {hasMarkedAuthoritative ? 'text-emerald-600' : 'text-stone-400'}">
+              <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z" clip-rule="evenodd" />
+            </svg>
+            <span>Authoritative</span>
+            {#if authoritativeCount > 0}
+              <span class="bg-white/80 px-1.5 py-0.5 rounded-full text-[10px] font-bold shadow-sm">{authoritativeCount}</span>
+            {/if}
+          </button>
+        </div>
         <div>
           by <UserLabel pubkey={event.pubkey} {createChild} />
           {#if event.created_at}

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -66,6 +66,23 @@
     return list;
   });
 
+  let contributors = $derived.by<string[]>(() => {
+    const list: string[] = [pubkey];
+    if (event?.tags) {
+      event.tags.forEach(([tag, val]) => {
+        if (tag === 'contributor' && val && !list.includes(val)) {
+          list.push(val);
+        }
+      });
+    }
+    historyEvents.forEach((rev) => {
+      if (rev.pubkey && !list.includes(rev.pubkey)) {
+        list.push(rev.pubkey);
+      }
+    });
+    return list;
+  });
+
   function scrollToHeading(headingTitle: string) {
     const cardEl = document.getElementById(`wikicard-${card.id}`);
     if (!cardEl) return;
@@ -798,6 +815,18 @@
             </ul>
           {/if}
         </details>
+      </div>
+
+      <!-- Contributors -->
+      <div class="mt-6 border-t border-stone-250 pt-4 text-xs text-stone-500">
+        <span class="font-semibold text-stone-700">Contributors:</span>
+        <div class="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+          {#each contributors as cPubkey}
+            <div class="inline-flex items-center">
+              <UserLabel pubkey={cPubkey} {createChild} />
+            </div>
+          {/each}
+        </div>
       </div>
 
     {:else if activeTab === 'discussion'}

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -312,7 +312,7 @@
   function edit() {
     const prevCard = { ...(card as ArticleCard) };
     if (event) {
-      prevCard.actualEvent = event;
+      prevCard.actualEvent = { ...event, tags: event.tags.map(t => [...t]) };
     }
     replaceSelf({
       id: next(),

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -55,16 +55,24 @@
     lines.forEach((line) => {
       const adMatch = line.match(/^(=+)\s+(.+)$/);
       if (adMatch) {
-        list.push({ title: adMatch[2].trim(), level: adMatch[1].length });
+        const level = adMatch[1].length;
+        if (level > 1) {
+          list.push({ title: adMatch[2].trim(), level });
+        }
         return;
       }
       const mdMatch = line.match(/^(#+)\s+(.+)$/);
       if (mdMatch) {
-        list.push({ title: mdMatch[2].trim(), level: mdMatch[1].length });
+        const level = mdMatch[1].length;
+        if (level > 1) {
+          list.push({ title: mdMatch[2].trim(), level });
+        }
       }
     });
     return list;
   });
+
+  let minHeadingLevel = $derived(headings.length > 0 ? Math.min(...headings.map(h => h.level)) : 2);
 
   let contributors = $derived.by<string[]>(() => {
     const list: string[] = [pubkey];
@@ -757,7 +765,7 @@
           </div>
           <ul class="space-y-1.5 text-sm">
             {#each headings as heading}
-              <li style:padding-left={`${(heading.level - 1) * 12}px`}>
+              <li style:padding-left={`${(heading.level - minHeadingLevel) * 12}px`}>
                 <a
                   href="javascript:void(0)"
                   onclick={() => scrollToHeading(heading.title)}

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -30,6 +30,67 @@
   let merging = $state(false);
   let nOthers = $state<number | undefined>(undefined);
   let copied = $state(false);
+  let isPinned = $state(false);
+
+  $effect(() => {
+    if (event) {
+      try {
+        const stored = localStorage.getItem('wikistr:pinned');
+        const pinned = stored ? JSON.parse(stored) : [];
+        if (Array.isArray(pinned)) {
+          isPinned = pinned.some((x: any) => x.dTag === dTag && x.pubkey === pubkey);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  });
+
+  $effect(() => {
+    if (event) {
+      try {
+        const stored = localStorage.getItem('wikistr:history');
+        let history = stored ? JSON.parse(stored) : [];
+        if (!Array.isArray(history)) history = [];
+        
+        const historyItem = {
+          dTag,
+          pubkey,
+          title: title || dTag,
+          timestamp: Date.now()
+        };
+        
+        history = history.filter((x: any) => !(x.dTag === dTag && x.pubkey === pubkey));
+        history.unshift(historyItem);
+        history = history.slice(0, 5);
+        
+        localStorage.setItem('wikistr:history', JSON.stringify(history));
+      } catch (e) {
+        console.error('Failed to update history', e);
+      }
+    }
+  });
+
+  function togglePin() {
+    isPinned = !isPinned;
+    try {
+      const stored = localStorage.getItem('wikistr:pinned');
+      let pinned = stored ? JSON.parse(stored) : [];
+      if (!Array.isArray(pinned)) pinned = [];
+      
+      if (isPinned) {
+        if (!pinned.some((x: any) => x.dTag === dTag && x.pubkey === pubkey)) {
+          pinned.push({ dTag, pubkey, title: title || dTag });
+        }
+      } else {
+        pinned = pinned.filter((x: any) => !(x.dTag === dTag && x.pubkey === pubkey));
+      }
+      localStorage.setItem('wikistr:pinned', JSON.stringify(pinned));
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
   let likeStatus: 'liked' | 'disliked' | unknown;
   let canLike = $state<boolean | undefined>();
   let seenOn = $state<string[]>([]);
@@ -537,6 +598,14 @@
           &nbsp;• &nbsp;
           <a class="cursor-pointer underline" onclick={shareCopy}>
             {#if copied}Copied!{:else}Share{/if}
+          </a>
+          &nbsp;• &nbsp;
+          <!-- svelte-ignore a11y_invalid_attribute -->
+          <a class="cursor-pointer underline inline-flex items-center space-x-0.5" onclick={togglePin}>
+            <svg xmlns="http://www.w3.org/2000/svg" fill={isPinned ? '#eab308' : 'none'} viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 text-amber-500 inline align-middle">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
+            </svg>
+            <span class="align-middle">{isPinned ? 'Unpin' : 'Pin'}</span>
           </a>
           &nbsp;• &nbsp;
           <a class="cursor-pointer underline" onmouseup={seeOthers}>{nOthers || ''} Versions</a>

--- a/src/cards/Article.svelte
+++ b/src/cards/Article.svelte
@@ -98,6 +98,57 @@
   let seenOn = $state<string[]>([]);
   let view = $state<'formatted' | 'asciidoc' | 'raw'>('formatted');
 
+  let privateTags = $state<string[]>([]);
+  let newPrivateTag = $state('');
+  let showAddPrivateTag = $state(false);
+
+  function loadPrivateTags() {
+    try {
+      const stored = localStorage.getItem('wikistr:private-tags');
+      const allPrivateTags = stored ? JSON.parse(stored) : {};
+      const key = `${pubkey}:${dTag}`;
+      privateTags = allPrivateTags[key] || [];
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  function addPrivateTag(tag: string) {
+    const cleanTag = tag.trim().toLowerCase();
+    if (!cleanTag) return;
+    try {
+      const stored = localStorage.getItem('wikistr:private-tags');
+      const allPrivateTags = stored ? JSON.parse(stored) : {};
+      const key = `${pubkey}:${dTag}`;
+      const existing = allPrivateTags[key] || [];
+      if (!existing.includes(cleanTag)) {
+        existing.push(cleanTag);
+        allPrivateTags[key] = existing;
+        localStorage.setItem('wikistr:private-tags', JSON.stringify(allPrivateTags));
+        privateTags = existing;
+        window.dispatchEvent(new Event('wikistr:dashboard-update'));
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  function removePrivateTag(tag: string) {
+    try {
+      const stored = localStorage.getItem('wikistr:private-tags');
+      const allPrivateTags = stored ? JSON.parse(stored) : {};
+      const key = `${pubkey}:${dTag}`;
+      let existing = allPrivateTags[key] || [];
+      existing = existing.filter((t: string) => t !== tag);
+      allPrivateTags[key] = existing;
+      localStorage.setItem('wikistr:private-tags', JSON.stringify(allPrivateTags));
+      privateTags = existing;
+      window.dispatchEvent(new Event('wikistr:dashboard-update'));
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
   // Wiki features state
   let activeTab = $state<'article' | 'discussion' | 'history'>('article');
   let comments = $state<NostrEvent[]>([]);
@@ -281,6 +332,7 @@
   }
 
   onMount(() => {
+    loadPrivateTags();
     // load this article
     if (articleCard.actualEvent) {
       event = articleCard.actualEvent;
@@ -591,8 +643,8 @@
             {formatDate(event.created_at)}
           {/if}
         </div>
-        {#if tagsList.length > 0}
-          <div class="flex flex-wrap gap-1.5 mt-2">
+        <div class="flex flex-wrap items-center gap-1.5 mt-2">
+          {#if tagsList.length > 0}
             {#each tagsList as tag}
               <button 
                 onclick={() => createChild({ id: next(), type: 'find', data: '#' + tag, preferredAuthors: [] })}
@@ -601,8 +653,59 @@
                 #{tag}
               </button>
             {/each}
-          </div>
-        {/if}
+          {/if}
+
+          <!-- Private Tags -->
+          {#each privateTags as ptag}
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-50 text-amber-700 border border-amber-200 shadow-sm">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-3 h-3 mr-0.5 text-amber-500">
+                <path fill-rule="evenodd" d="M12 1.5a5.25 5.25 0 0 0-5.25 5.25v3a3 3 0 0 0-3 3v6.75a3 3 0 0 0 3 3h10.5a3 3 0 0 0 3-3v-6.75a3 3 0 0 0-3-3v-3c0-2.9-2.35-5.25-5.25-5.25Zm3.75 8.25v-3a3.75 3.75 0 1 0-7.5 0v3h7.5Z" clip-rule="evenodd" />
+              </svg>
+              <span>{ptag}</span>
+              <button 
+                onclick={() => removePrivateTag(ptag)} 
+                class="ml-1 text-amber-400 hover:text-amber-600 focus:outline-none font-bold"
+                title="Remove private tag"
+              >
+                &times;
+              </button>
+            </span>
+          {/each}
+
+          <!-- Add Private Tag Toggle/Input -->
+          {#if showAddPrivateTag}
+            <form 
+              onsubmit={(e) => {
+                e.preventDefault();
+                addPrivateTag(newPrivateTag);
+                newPrivateTag = '';
+                showAddPrivateTag = false;
+              }}
+              class="inline-flex items-center"
+            >
+              <input 
+                type="text" 
+                bind:value={newPrivateTag} 
+                placeholder="private tag"
+                class="px-2 py-0.5 text-xs border border-stone-300 rounded focus:ring-1 focus:ring-amber-500 focus:outline-none w-24"
+                autoFocus
+                onblur={() => {
+                  setTimeout(() => {
+                    if (!newPrivateTag) showAddPrivateTag = false;
+                  }, 200);
+                }}
+              />
+            </form>
+          {:else}
+            <button 
+              onclick={() => showAddPrivateTag = true}
+              class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border border-dashed border-stone-300 text-stone-500 hover:border-amber-400 hover:text-amber-600 transition-colors"
+              title="Add a private bookmark/tag for your eyes only"
+            >
+              + Private Tag
+            </button>
+          {/if}
+        </div>
         <div>
           <a class="cursor-pointer underline" onclick={edit}>
             {#if event?.pubkey === $account?.pubkey}

--- a/src/cards/Editor.svelte
+++ b/src/cards/Editor.svelte
@@ -28,6 +28,15 @@
   const editorCard = card as EditorCard;
 
   let data = $state<EditorData>({ ...editorCard.data });
+  let tagsInput = $state(data.tags ? data.tags.join(', ') : '');
+
+  function getParsedTags(): string[] {
+    return tagsInput
+      .split(',')
+      .map((t) => t.trim().toLowerCase())
+      .filter((t) => t.length > 0);
+  }
+
   let error = $state<string | undefined>();
   let targets: { url: string; status: 'pending' | 'success' | 'failure'; message?: string }[] =
     $state([]);
@@ -140,6 +149,10 @@
     };
     if (data.title !== eventTemplate.tags[0][1]) eventTemplate.tags.push(['title', data.title]);
     if (data.summary) eventTemplate.tags.push(['summary', data.summary]);
+    const parsedTags = getParsedTags();
+    parsedTags.forEach((tag) => {
+      eventTemplate.tags.push(['t', tag]);
+    });
 
     try {
       let event = await signer.signEvent(eventTemplate);
@@ -350,6 +363,17 @@
         ></textarea></label
       >
     </details>
+  </div>
+  <div class="mt-4">
+    <label class="block text-sm font-semibold text-gray-700 mb-1">
+      Categories / Tags
+    </label>
+    <input
+      type="text"
+      bind:value={tagsInput}
+      placeholder="e.g. science, history, philosophy (comma-separated)"
+      class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md"
+    />
   </div>
 {/if}
 

--- a/src/cards/Editor.svelte
+++ b/src/cards/Editor.svelte
@@ -141,8 +141,18 @@
   );
 
   async function publish() {
+    let userRelays: string[] = [];
+    try {
+      const rl = await loadRelayList($account!.pubkey);
+      if (rl && rl.items) {
+        userRelays = rl.items.filter((ri) => ri.write).map((ri) => ri.url);
+      }
+    } catch (e) {
+      console.warn("Failed to load user's relay list", e);
+    }
+
     targets = unique(
-      (await loadRelayList($account!.pubkey)).items.filter((ri) => ri.write).map((ri) => ri.url),
+      userRelays,
       DEFAULT_WIKI_RELAYS
     ).map((url) => ({ url, status: 'pending' }));
     error = undefined;
@@ -222,8 +232,18 @@
     const originalPubkey = data.previous.data[1];
     const originalDTag = data.previous.data[0];
 
+    let userRelays: string[] = [];
+    try {
+      const rl = await loadRelayList($account!.pubkey);
+      if (rl && rl.items) {
+        userRelays = rl.items.filter((ri) => ri.write).map((ri) => ri.url);
+      }
+    } catch (e) {
+      console.warn("Failed to load user's relay list", e);
+    }
+
     targets = unique(
-      (await loadRelayList($account!.pubkey)).items.filter((ri) => ri.write).map((ri) => ri.url),
+      userRelays,
       DEFAULT_WIKI_RELAYS
     ).map((url) => ({ url, status: 'pending' }));
     error = undefined;

--- a/src/cards/Editor.svelte
+++ b/src/cards/Editor.svelte
@@ -6,10 +6,12 @@
   import { DEFAULT_WIKI_RELAYS } from '$lib/defaults';
   import { wikiKind, gitPatchKind, account, signer } from '$lib/nostr';
   import type { ArticleCard, Card, EditorCard, EditorData } from '$lib/types.ts';
+  import { naddrEncode } from '@nostr/tools/nip19';
   import {
     getTagOr,
     next,
     turnWikilinksIntoAsciidocLinks,
+    appendLinkMacroToNostrLinks,
     unique,
     urlWithoutScheme
   } from '$lib/utils';
@@ -100,7 +102,7 @@
     }
   });
 
-  function insertLink(targetTitle: string) {
+  function insertLink(targetTitle: string, naddr?: string) {
     if (!textareaEl) return;
     const start = textareaEl.selectionStart;
     const end = textareaEl.selectionEnd;
@@ -108,10 +110,15 @@
     const selection = text.substring(start, end);
 
     let linkText = '';
-    if (selection) {
-      linkText = `[[${targetTitle}|${selection}]]`;
+    if (naddr) {
+      const label = selection || targetTitle;
+      linkText = `nostr:${naddr}[${label}]`;
     } else {
-      linkText = `[[${targetTitle}]]`;
+      if (selection) {
+        linkText = `[[${targetTitle}|${selection}]]`;
+      } else {
+        linkText = `[[${targetTitle}]]`;
+      }
     }
 
     data.content = text.substring(0, start) + linkText + text.substring(end);
@@ -313,7 +320,11 @@
               {#each lookupResults as res (res.id)}
                 <button
                   type="button"
-                  onclick={() => insertLink(getTagOr(res, 'title') || getTagOr(res, 'd'))}
+                  onclick={() => {
+                    const d = getTagOr(res, 'd');
+                    const naddr = naddrEncode({ pubkey: res.pubkey, kind: res.kind, identifier: d });
+                    insertLink(getTagOr(res, 'title') || d, naddr);
+                  }}
                   class="w-full text-left p-2 hover:bg-stone-50 text-xs font-medium text-stone-700 flex justify-between items-center focus:outline-none transition-colors border-none"
                 >
                   <span class="font-semibold text-indigo-700">{getTagOr(res, 'title') || getTagOr(res, 'd')}</span>
@@ -337,7 +348,7 @@
       {#if previewing}
         <div class="prose prose-p:my-0 prose-li:my-0">
           <SvelteAsciidoc
-            source={turnWikilinksIntoAsciidocLinks(data.content)}
+            source={appendLinkMacroToNostrLinks(turnWikilinksIntoAsciidocLinks(data.content))}
             naturalRenderers={{ a: WikilinkComponent as any }}
           />
         </div>

--- a/src/cards/Editor.svelte
+++ b/src/cards/Editor.svelte
@@ -180,7 +180,7 @@
   }
 
   async function suggest() {
-    if (!isSomeoneElsesArticle || !data.previous) return;
+    if (!isSomeoneElsesArticle || !data.previous || data.previous.type !== 'article') return;
     const originalPubkey = data.previous.data[1];
     const originalDTag = data.previous.data[0];
 

--- a/src/cards/Editor.svelte
+++ b/src/cards/Editor.svelte
@@ -148,9 +148,26 @@
 
     data.title = data.title.trim();
 
+    let version = 1;
+    if (data.previous && 'actualEvent' in data.previous && data.previous.actualEvent) {
+      const prevEvent = data.previous.actualEvent;
+      const prevVersionTag = prevEvent.tags.find(([k]) => k === 'version' || k === 'revision');
+      if (prevVersionTag) {
+        const parsed = parseInt(prevVersionTag[1], 10);
+        if (!isNaN(parsed)) {
+          version = parsed + 1;
+        }
+      } else {
+        version = 2;
+      }
+    }
+
     let eventTemplate: EventTemplate = {
       kind: wikiKind,
-      tags: [['d', normalizeIdentifier(data.title)]],
+      tags: [
+        ['d', normalizeIdentifier(data.title)],
+        ['version', String(version)]
+      ],
       content: data.content.trim(),
       created_at: Math.round(Date.now() / 1000)
     };

--- a/src/cards/Editor.svelte
+++ b/src/cards/Editor.svelte
@@ -4,7 +4,7 @@
 
   import WikilinkComponent from '$components/WikilinkComponent.svelte';
   import { DEFAULT_WIKI_RELAYS } from '$lib/defaults';
-  import { wikiKind, account, signer } from '$lib/nostr';
+  import { wikiKind, gitPatchKind, account, signer } from '$lib/nostr';
   import type { ArticleCard, Card, EditorCard, EditorData } from '$lib/types.ts';
   import {
     getTagOr,
@@ -31,6 +31,12 @@
   let targets: { url: string; status: 'pending' | 'success' | 'failure'; message?: string }[] =
     $state([]);
   let previewing = $state(false);
+
+  let isSomeoneElsesArticle = $derived(
+    data.previous &&
+    data.previous.type === 'article' &&
+    data.previous.data[1] !== $account?.pubkey
+  );
 
   async function publish() {
     targets = unique(
@@ -87,11 +93,74 @@
       return;
     }
   }
+
+  async function suggest() {
+    if (!isSomeoneElsesArticle || !data.previous) return;
+    const originalPubkey = data.previous.data[1];
+    const originalDTag = data.previous.data[0];
+
+    targets = unique(
+      (await loadRelayList($account!.pubkey)).items.filter((ri) => ri.write).map((ri) => ri.url),
+      DEFAULT_WIKI_RELAYS
+    ).map((url) => ({ url, status: 'pending' }));
+    error = undefined;
+
+    data.title = data.title.trim();
+
+    let eventTemplate: EventTemplate = {
+      kind: gitPatchKind,
+      tags: [
+        ['a', `${wikiKind}:${originalPubkey}:${originalDTag}`, (data.previous as any).relayHints?.[0] || ''],
+        ['p', originalPubkey]
+      ],
+      content: data.content.trim(),
+      created_at: Math.round(Date.now() / 1000)
+    };
+    if (data.title) eventTemplate.tags.push(['title', data.title]);
+    if (data.summary) eventTemplate.tags.push(['summary', data.summary]);
+
+    try {
+      let event = await signer.signEvent(eventTemplate);
+      let successes: string[] = [];
+
+      await Promise.all(
+        targets.map(async (target, i) => {
+          try {
+            const r = await pool.ensureRelay(target.url);
+            await r.publish(event);
+            target.status = 'success';
+            successes.push(target.url);
+          } catch (err) {
+            target.status = 'failure';
+            target.message = String(err);
+          }
+          targets[i] = target;
+          targets = targets;
+        })
+      );
+
+      if (successes.length) {
+        setTimeout(() => {
+          if (data.previous) {
+            replaceSelf(data.previous);
+          }
+        }, 1400);
+      }
+    } catch (err) {
+      error = String(err);
+      targets = [];
+      return;
+    }
+  }
 </script>
 
 <div class="my-4 font-bold text-4xl">
   {#if editorCard.data.content}
-    Editing an article
+    {#if isSomeoneElsesArticle}
+      Suggesting changes to article
+    {:else}
+      Editing an article
+    {/if}
   {:else}
     Creating an article
   {/if}
@@ -103,7 +172,8 @@
       <input
         placeholder="example: Greek alphabet"
         bind:value={data.title}
-        class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md ml-2"
+        disabled={isSomeoneElsesArticle}
+        class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md ml-2 disabled:bg-gray-100 disabled:text-gray-500"
       /></label
     >
   </div>
@@ -168,12 +238,27 @@
       {error}
     </div>
   {/if}
-  <div class="mt-2 flex justify-between">
-    <button
-      onclick={publish}
-      class="cursor-pointer inline-flex items-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-      >Save</button
-    >
+  <div class="mt-2 flex justify-between items-center">
+    <div class="flex space-x-2">
+      {#if isSomeoneElsesArticle}
+        <button
+          onclick={suggest}
+          class="cursor-pointer inline-flex items-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-emerald-600 hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500"
+          >Submit Change</button
+        >
+        <button
+          onclick={publish}
+          class="cursor-pointer inline-flex items-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >Publish Fork</button
+        >
+      {:else}
+        <button
+          onclick={publish}
+          class="cursor-pointer inline-flex items-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >Save</button
+        >
+      {/if}
+    </div>
     <button
       onclick={() => {
         previewing = !previewing;

--- a/src/cards/Editor.svelte
+++ b/src/cards/Editor.svelte
@@ -27,6 +27,7 @@
 
   let { replaceSelf, card }: Props = $props();
 
+  // svelte-ignore state_referenced_locally
   const editorCard = card as EditorCard;
 
   let data = $state<EditorData>({ ...editorCard.data });
@@ -393,10 +394,11 @@
     </details>
   </div>
   <div class="mt-4">
-    <label class="block text-sm font-semibold text-gray-700 mb-1">
+    <label for="categories-tags-input" class="block text-sm font-semibold text-gray-700 mb-1">
       Categories / Tags
     </label>
     <input
+      id="categories-tags-input"
       type="text"
       bind:value={tagsInput}
       placeholder="e.g. science, history, philosophy (comma-separated)"

--- a/src/cards/Editor.svelte
+++ b/src/cards/Editor.svelte
@@ -16,6 +16,7 @@
   import { pool } from '@nostr/gadgets/global';
   import { loadRelayList } from '@nostr/gadgets/lists';
   import { normalizeIdentifier } from '@nostr/tools/nip54';
+  import debounce from 'debounce';
 
   interface Props {
     replaceSelf: (card: Card) => void;
@@ -31,6 +32,90 @@
   let targets: { url: string; status: 'pending' | 'success' | 'failure'; message?: string }[] =
     $state([]);
   let previewing = $state(false);
+
+  // Article lookup state
+  let textareaEl = $state<HTMLTextAreaElement | null>(null);
+  let showLookup = $state(false);
+  let lookupQuery = $state('');
+  let lookupResults = $state<any[]>([]);
+  let lookupSearching = $state(false);
+  let lookupSub = $state<any>(null);
+
+  async function performLookupSearch() {
+    if (lookupSub) {
+      lookupSub.close();
+      lookupSub = null;
+    }
+    lookupResults = [];
+    if (!lookupQuery.trim()) {
+      lookupSearching = false;
+      return;
+    }
+    lookupSearching = true;
+
+    const searchRelays = unique(
+      (await loadRelayList($account?.pubkey || '')).items.filter((ri) => ri.read).map((ri) => ri.url),
+      DEFAULT_WIKI_RELAYS
+    );
+
+    lookupSub = pool.subscribeMany(
+      searchRelays,
+      [
+        {
+          kinds: [wikiKind],
+          limit: 50
+        }
+      ],
+      {
+        onevent(evt) {
+          const title = getTagOr(evt, 'title') || getTagOr(evt, 'd');
+          if (
+            title.toLowerCase().includes(lookupQuery.toLowerCase()) &&
+            !lookupResults.some((r) => r.id === evt.id)
+          ) {
+            lookupResults = [...lookupResults, evt].slice(0, 10);
+          }
+        },
+        oneose() {
+          lookupSearching = false;
+        }
+      }
+    );
+  }
+
+  const debouncedLookup = debounce(performLookupSearch, 400);
+
+  $effect(() => {
+    if (lookupQuery !== undefined) {
+      debouncedLookup();
+    }
+  });
+
+  function insertLink(targetTitle: string) {
+    if (!textareaEl) return;
+    const start = textareaEl.selectionStart;
+    const end = textareaEl.selectionEnd;
+    const text = data.content;
+    const selection = text.substring(start, end);
+
+    let linkText = '';
+    if (selection) {
+      linkText = `[[${targetTitle}|${selection}]]`;
+    } else {
+      linkText = `[[${targetTitle}]]`;
+    }
+
+    data.content = text.substring(0, start) + linkText + text.substring(end);
+    showLookup = false;
+    lookupQuery = '';
+    lookupResults = [];
+
+    setTimeout(() => {
+      textareaEl?.focus();
+      const newCursorPos = start + linkText.length;
+      textareaEl?.setSelectionRange(newCursorPos, newCursorPos);
+    }, 50);
+  }
 
   let isSomeoneElsesArticle = $derived(
     data.previous &&
@@ -180,7 +265,62 @@
   <div class="mt-2">
     <!-- svelte-ignore a11y_label_has_associated_control -->
     <label>
-      Article
+      <div class="flex justify-between items-center mt-1 mb-1">
+        <span class="font-semibold text-stone-700">Article</span>
+        {#if !previewing}
+          <button
+            type="button"
+            onclick={() => showLookup = !showLookup}
+            class="text-xs text-indigo-600 hover:text-indigo-800 font-semibold focus:outline-none flex items-center bg-indigo-50 px-2.5 py-1 rounded border border-indigo-150 transition-colors"
+          >
+            <svg class="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" /></svg>
+            Insert Link
+          </button>
+        {/if}
+      </div>
+
+      {#if showLookup && !previewing}
+        <div class="my-2 p-3 bg-stone-50 border border-stone-200 rounded-lg shadow-inner">
+          <div class="text-xs font-semibold text-stone-700 mb-1.5 flex justify-between items-center">
+            <span>Search articles to reference:</span>
+            <button onclick={() => { showLookup = false; lookupQuery = ''; }} class="text-[10px] text-stone-400 hover:text-stone-600">Cancel</button>
+          </div>
+          <div class="flex gap-2">
+            <input
+              bind:value={lookupQuery}
+              placeholder="Type title to lookup..."
+              class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-stone-300 rounded-md p-1.5"
+            />
+          </div>
+          {#if lookupSearching}
+            <div class="text-[10px] text-stone-400 mt-2 italic">Searching relays...</div>
+          {/if}
+          {#if lookupResults.length > 0}
+            <div class="mt-2 border border-stone-200 rounded divide-y divide-stone-150 max-h-40 overflow-y-auto bg-white shadow-sm">
+              {#each lookupResults as res (res.id)}
+                <button
+                  type="button"
+                  onclick={() => insertLink(getTagOr(res, 'title') || getTagOr(res, 'd'))}
+                  class="w-full text-left p-2 hover:bg-stone-50 text-xs font-medium text-stone-700 flex justify-between items-center focus:outline-none transition-colors border-none"
+                >
+                  <span class="font-semibold text-indigo-700">{getTagOr(res, 'title') || getTagOr(res, 'd')}</span>
+                  <span class="text-[9px] text-stone-400">by {res.pubkey.substring(0, 8)}</span>
+                </button>
+              {/each}
+            </div>
+          {:else if lookupQuery && !lookupSearching}
+            <div class="text-[10px] text-stone-400 mt-2 italic">No matching pages found on relays. You can still insert this as a new wikilink:</div>
+            <button
+              type="button"
+              onclick={() => insertLink(lookupQuery)}
+              class="mt-2 px-3 py-1 bg-stone-200 hover:bg-stone-300 rounded text-[10px] font-semibold text-stone-700 transition-colors"
+            >
+              Insert "[[{lookupQuery}]]"
+            </button>
+          {/if}
+        </div>
+      {/if}
+
       {#if previewing}
         <div class="prose prose-p:my-0 prose-li:my-0">
           <SvelteAsciidoc
@@ -190,6 +330,7 @@
         </div>
       {:else}
         <textarea
+          bind:this={textareaEl}
           placeholder="The **Greek alphabet** has been used to write the [[Greek language]] sincie the late 9th or early 8th century BC. The Greek alphabet is the ancestor of the [[Latin]] and [[Cyrillic]] scripts."
           bind:value={data.content}
           class="h-64 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md"

--- a/src/cards/New.svelte
+++ b/src/cards/New.svelte
@@ -20,7 +20,8 @@
         id: next(),
         type: 'find',
         data: normalizeIdentifier(query),
-        preferredAuthors: []
+        preferredAuthors: [],
+        redirect: false
       };
       replaceNewCard(newCard);
       query = '';

--- a/src/cards/New.svelte
+++ b/src/cards/New.svelte
@@ -10,6 +10,7 @@
 
   let { replaceNewCard }: Props = $props();
   let query = $state('');
+  let newTitle = $state('');
 
   function search(ev: SubmitEvent) {
     ev.preventDefault();
@@ -25,19 +26,57 @@
       query = '';
     }
   }
+
+  function createArticle(ev: SubmitEvent) {
+    ev.preventDefault();
+
+    if (newTitle) {
+      replaceNewCard({
+        id: next(),
+        type: 'editor',
+        data: {
+          title: newTitle,
+          summary: '',
+          content: ''
+        }
+      } as any);
+      newTitle = '';
+    }
+  }
 </script>
 
-<form onsubmit={search} class="mt- flex rounded-md shadow-sm">
-  <div class="relative flex items-stretch flex-grow focus-within:z-10">
-    <input
-      bind:value={query}
-      class="focus:ring-indigo-500 focus:border-indigo-500 block w-full rounded-none rounded-l-md sm:text-sm border-gray-300"
-      placeholder="article name or search term"
-    />
+<div>
+  <div class="text-sm font-semibold text-gray-700 mb-2">Search for an article:</div>
+  <form onsubmit={search} class="flex rounded-md shadow-sm mb-6">
+    <div class="relative flex items-stretch flex-grow focus-within:z-10">
+      <input
+        bind:value={query}
+        class="focus:ring-indigo-500 focus:border-indigo-500 block w-full rounded-none rounded-l-md sm:text-sm border-gray-300"
+        placeholder="article name or search term"
+      />
+    </div>
+    <button
+      type="submit"
+      class="-ml-px inline-flex items-center space-x-2 px-3 py-2 border border-gray-300 text-sm font-medium rounded-r-md bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 text-white"
+      >Go</button
+    >
+  </form>
+
+  <div class="border-t border-stone-200 pt-6">
+    <div class="text-sm font-semibold text-gray-700 mb-2">Or, create a new article:</div>
+    <form onsubmit={createArticle} class="flex rounded-md shadow-sm">
+      <div class="relative flex items-stretch flex-grow focus-within:z-10">
+        <input
+          bind:value={newTitle}
+          class="focus:ring-indigo-500 focus:border-indigo-500 block w-full rounded-none rounded-l-md sm:text-sm border-gray-300"
+          placeholder="e.g., Quantum physics"
+        />
+      </div>
+      <button
+        type="submit"
+        class="-ml-px inline-flex items-center space-x-2 px-3 py-2 border border-gray-300 text-sm font-medium rounded-r-md bg-emerald-600 hover:bg-emerald-700 focus:outline-none focus:ring-1 focus:ring-emerald-500 focus:border-emerald-500 text-white"
+        >Create</button
+      >
+    </form>
   </div>
-  <button
-    type="submit"
-    class="-ml-px inline-flex items-center space-x-2 px-3 py-2 border border-gray-300 text-sm font-medium rounded-r-md bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 text-white"
-    >Go</button
-  >
-</form>
+</div>

--- a/src/cards/Recent.svelte
+++ b/src/cards/Recent.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+  import debounce from 'debounce';
+  import { onDestroy, onMount } from 'svelte';
+  import type { SubCloser } from '@nostr/tools/abstract-pool';
+  import type { Event, NostrEvent } from '@nostr/tools/pure';
+
+  import {
+    wikiKind,
+    account,
+    wot,
+    getBasicUserWikiRelays,
+    userWikiRelays
+  } from '$lib/nostr';
+  import type { ArticleCard, Card } from '$lib/types';
+  import { addUniqueTaggedReplaceable, getTagOr, next } from '$lib/utils';
+  import { subscribeAllOutbox } from '$lib/outbox';
+  import ArticleListItem from '$components/ArticleListItem.svelte';
+  import RelayItem from '$components/RelayItem.svelte';
+  import { DEFAULT_WIKI_RELAYS } from '$lib/defaults';
+  import { pool } from '@nostr/gadgets/global';
+
+  interface Props {
+    createChild: (card: Card) => void;
+  }
+
+  let { createChild }: Props = $props();
+  let seenCache: { [id: string]: string[] } = {};
+  let results = $state<Event[]>([]);
+
+  const feeds = [normalFeed, followsFeed];
+  let current = $state(0);
+
+  const update = debounce(() => {
+    // sort by an average of newness and wotness
+    results.sort((a, b) => {
+      const wotA = $wot[a.pubkey] || 0;
+      const wotB = $wot[b.pubkey] || 0;
+      let wotAvg = (wotA + wotB) / 2 || 1;
+      let tsAvg = (a.created_at + b.created_at) / 2;
+      return wotB / wotAvg + b.created_at / tsAvg - (wotA / wotAvg + a.created_at / tsAvg);
+    });
+    results = results;
+    seenCache = seenCache;
+  }, 500);
+
+  let close = () => {};
+
+  onDestroy(() => {
+    close();
+  });
+
+  function openArticle(result: Event) {
+    createChild({
+      id: next(),
+      type: 'article',
+      data: [getTagOr(result, 'd'), result.pubkey],
+      actualEvent: result,
+      relayHints: seenCache[result.id] || []
+    } as ArticleCard);
+  }
+
+  function restart() {
+    close();
+    results = [];
+    close = feeds[current]();
+  }
+
+  setTimeout(restart, 400);
+
+  function normalFeed() {
+    let sub: SubCloser | undefined;
+    let cancel = account.subscribe(async (account) => {
+      if (sub) sub.close();
+
+      sub = pool.subscribeMany(
+        account ? await getBasicUserWikiRelays(account.pubkey) : DEFAULT_WIKI_RELAYS,
+        [
+          {
+            kinds: [wikiKind],
+            limit: 15
+          }
+        ],
+        {
+          id: 'recent',
+          onevent,
+          receivedEvent
+        }
+      );
+    });
+
+    return () => {
+      if (sub) sub.close();
+      cancel();
+    };
+  }
+
+  function followsFeed() {
+    let exited = false;
+
+    let subc: SubCloser;
+    let wotsubclose = wot.subscribe((wot) => {
+      if (exited) {
+        return;
+      }
+
+      const eligibleKeys = Object.entries(wot)
+        .filter(([_, v]) => v > 170)
+        .map(([k]) => k);
+
+      subc = subscribeAllOutbox(
+        eligibleKeys,
+        { kinds: [wikiKind], limit: 20 },
+        { id: 'alloutbox', onevent, receivedEvent }
+      );
+    });
+
+    return () => {
+      exited = true;
+      wotsubclose();
+      subc?.close?.();
+    };
+  }
+
+  function onevent(evt: NostrEvent) {
+    if (addUniqueTaggedReplaceable(results, evt)) update();
+  }
+
+  function receivedEvent(relay: any, id: string) {
+    if (!(id in seenCache)) seenCache[id] = [];
+    if (seenCache[id].indexOf(relay.url) === -1) seenCache[id].push(relay.url);
+  }
+</script>
+
+<div class="flex items-center justify-between mb-4">
+  <div class="font-bold text-4xl">
+    {#if feeds[current] === normalFeed}
+      Recent Articles
+    {:else if feeds[current] === followsFeed}
+      Articles from Contacts
+    {/if}
+  </div>
+  {#if $account}
+    <button
+      onclick={() => {
+        current = (current + 1) % feeds.length;
+        restart();
+      }}
+      type="button"
+      class="inline-flex items-center space-x-2 px-3 py-1.5 border border-gray-300 text-xs font-medium rounded-md bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 text-white"
+    >
+      {#if feeds[current] === normalFeed}
+        Show Contacts
+      {:else if feeds[current] === followsFeed}
+        Show Relays
+      {/if}
+    </button>
+  {/if}
+</div>
+
+{#if feeds[current] === normalFeed}
+  <div class="flex items-center flex-wrap gap-1 mb-6 text-sm text-stone-500">
+    <span class="mr-1">from</span>
+    {#each $userWikiRelays as url}
+      <RelayItem {url} {createChild} />
+    {/each}
+  </div>
+{/if}
+
+<div class="space-y-4">
+  {#each results as result (result.id)}
+    <ArticleListItem event={result} {openArticle} />
+  {/each}
+</div>

--- a/src/cards/Relay.svelte
+++ b/src/cards/Relay.svelte
@@ -4,13 +4,13 @@
   import type { NostrEvent } from '@nostr/tools/pure';
   import { pool } from '@nostr/gadgets/global';
 
-  import type { ArticleCard, Card } from '$lib/types';
+  import type { ArticleCard, RelayCard, Card } from '$lib/types';
   import { addUniqueTaggedReplaceable, getTagOr, next, urlWithoutScheme } from '$lib/utils';
   import { wikiKind } from '$lib/nostr';
   import ArticleListItem from '$components/ArticleListItem.svelte';
 
   interface Props {
-    card: Card;
+    card: RelayCard;
     replaceSelf: (card: Card) => void;
     createChild: (card: Card) => void;
   }

--- a/src/cards/Search.svelte
+++ b/src/cards/Search.svelte
@@ -103,7 +103,7 @@
     const update = debounce(() => {
       // sort by exact matches first, then by authoritative score (WoT + reactions)
       let normalizedIdentifier = normalizeIdentifier(query);
-      results = results.sort((a, b) => {
+      results = [...results].sort((a, b) => {
         if (
           !isTagQuery &&
           getTagOr(a, 'd') === normalizedIdentifier &&
@@ -149,7 +149,7 @@
                     [targetA]: [...current, evt]
                   };
                   // Re-sort results inline
-                  results = results.sort((a, b) => {
+                  results = [...results].sort((a, b) => {
                     if (
                       !isTagQuery &&
                       getTagOr(a, 'd') === normalizedIdentifier &&
@@ -286,22 +286,26 @@
   const debouncedPerformSearch = debounce(performSearch, 400);
 
   function openArticle(result: Event, ev?: MouseEvent, direct?: boolean) {
-    let articleCard: ArticleCard = {
-      id: next(),
-      type: 'article',
-      data: [getTagOr(result, 'd'), result.pubkey],
-      relayHints: seenCache[result.id],
-      actualEvent: result,
-      versions:
-        getTagOr(result, 'd') === normalizeIdentifier(query)
-          ? results.filter((evt) => getTagOr(evt, 'd') === normalizeIdentifier(query))
-          : undefined
-    };
-    if (ev?.button === 1) createChild(articleCard);
-    else if (direct)
-      // if this is called with 'direct' we won't give it a back button
-      replaceSelf(articleCard);
-    else replaceSelf({ ...articleCard, back: card }); // otherwise we will
+    try {
+      let articleCard: ArticleCard = {
+        id: next(),
+        type: 'article',
+        data: [getTagOr(result, 'd'), result.pubkey],
+        relayHints: seenCache[result.id],
+        actualEvent: result,
+        versions:
+          getTagOr(result, 'd') === normalizeIdentifier(query)
+            ? results.filter((evt) => getTagOr(evt, 'd') === normalizeIdentifier(query))
+            : undefined
+      };
+      if (ev?.button === 1) createChild(articleCard);
+      else if (direct)
+        // if this is called with 'direct' we won't give it a back button
+        replaceSelf(articleCard);
+      else replaceSelf({ ...articleCard, back: card }); // otherwise we will
+    } catch (err) {
+      alert("Error in openArticle: " + err);
+    }
   }
 
   function startEditing() {

--- a/src/cards/Search.svelte
+++ b/src/cards/Search.svelte
@@ -146,33 +146,8 @@
           onevent(evt) {
             tried = true;
 
-            if (!isTagQuery && searchCard.preferredAuthors.includes(evt.pubkey)) {
-              // we found an exact match that fits the list of preferred authors
-              // jump straight into it
-              redirected = true;
-              if (redirectTimeout) clearTimeout(redirectTimeout);
-              openArticle(evt, undefined, true);
-            }
-
             if (addUniqueTaggedReplaceable(results, evt)) {
               update();
-
-              // If we have not redirected yet, check if this is an exact match and schedule a fallback redirect
-              if (!isTagQuery && !redirected && getTagOr(evt, 'd') === normalizeIdentifier(query)) {
-                if (!redirectTimeout) {
-                  redirectTimeout = setTimeout(() => {
-                    if (redirected) return;
-                    // Find the best exact match from results (sorted by WoT)
-                    const exactMatches = results.filter(
-                      (r) => getTagOr(r, 'd') === normalizeIdentifier(query)
-                    );
-                    if (exactMatches.length > 0) {
-                      redirected = true;
-                      openArticle(exactMatches[0], undefined, true);
-                    }
-                  }, 800);
-                }
-              }
             }
           },
           oneose,

--- a/src/cards/Search.svelte
+++ b/src/cards/Search.svelte
@@ -34,6 +34,8 @@
   let uwrcancel: () => void;
   let search: SubCloser;
   let subs: SubCloser[] = [];
+  let redirectTimeout: ReturnType<typeof setTimeout> | undefined;
+  let redirected = false;
 
   onMount(() => {
     query = searchCard.data;
@@ -58,6 +60,10 @@
     if (uwrcancel) uwrcancel();
     subs.forEach((sub) => sub.close());
     if (search) search.close();
+    if (redirectTimeout) {
+      clearTimeout(redirectTimeout);
+      redirectTimeout = undefined;
+    }
   }
 
   async function performSearch() {
@@ -66,6 +72,7 @@
     tried = false;
     eosed = 0;
     results = [];
+    redirected = false;
 
     setTimeout(() => {
       tried = true;
@@ -133,10 +140,31 @@
             if (searchCard.preferredAuthors.includes(evt.pubkey)) {
               // we found an exact match that fits the list of preferred authors
               // jump straight into it
+              redirected = true;
+              if (redirectTimeout) clearTimeout(redirectTimeout);
               openArticle(evt, undefined, true);
             }
 
-            if (addUniqueTaggedReplaceable(results, evt)) update();
+            if (addUniqueTaggedReplaceable(results, evt)) {
+              update();
+
+              // If we have not redirected yet, check if this is an exact match and schedule a fallback redirect
+              if (!redirected && getTagOr(evt, 'd') === normalizeIdentifier(query)) {
+                if (!redirectTimeout) {
+                  redirectTimeout = setTimeout(() => {
+                    if (redirected) return;
+                    // Find the best exact match from results (sorted by WoT)
+                    const exactMatches = results.filter(
+                      (r) => getTagOr(r, 'd') === normalizeIdentifier(query)
+                    );
+                    if (exactMatches.length > 0) {
+                      redirected = true;
+                      openArticle(exactMatches[0], undefined, true);
+                    }
+                  }, 800);
+                }
+              }
+            }
           },
           oneose,
           receivedEvent
@@ -252,7 +280,7 @@
     </p>
     <button
       on:click={() => {
-        replaceSelf({ id: next(), type: 'editor', data: { title: query, previous: card } });
+        replaceSelf({ id: next(), type: 'editor', data: { title: query, summary: '', content: '', previous: card } });
       }}
       class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
     >

--- a/src/cards/Search.svelte
+++ b/src/cards/Search.svelte
@@ -205,7 +205,7 @@
       }
     }
 
-    function receivedEvent(relay: AbstractRelay, id: string) {
+    function receivedEvent(relay: any, id: string) {
       if (!(id in seenCache)) seenCache[id] = [];
       if (seenCache[id].indexOf(relay.url) === -1) seenCache[id].push(relay.url);
     }

--- a/src/cards/Search.svelte
+++ b/src/cards/Search.svelte
@@ -8,7 +8,7 @@
   import { loadRelayList } from '@nostr/gadgets/lists';
   import { normalizeIdentifier } from '@nostr/tools/nip54';
 
-  import { wot, wikiKind, userWikiRelays } from '$lib/nostr';
+  import { wot, wikiKind, reactionKind, userWikiRelays } from '$lib/nostr';
   import type { ArticleCard, SearchCard, Card } from '$lib/types';
   import { addUniqueTaggedReplaceable, getTagOr, next, unique } from '$lib/utils';
   import { DEFAULT_SEARCH_RELAYS } from '$lib/defaults';
@@ -17,29 +17,31 @@
   import { page } from '$app/state';
   import { cards } from '$lib/state';
 
-  export let card: Card;
-  export let replaceSelf: (card: Card) => void;
-  export let createChild: (card: Card) => void;
-  let tried = false;
-  let eosed = 0;
-  let editable = false;
+  interface Props {
+    card: Card;
+    replaceSelf: (card: Card) => void;
+    createChild: (card: Card) => void;
+  }
 
-  const searchCard = card as SearchCard;
+  let { card, replaceSelf, createChild }: Props = $props();
+  let tried = $state(false);
+  let eosed = $state(0);
+  let editable = $state(false);
 
-  let query: string;
+  let searchCard = $derived(card as SearchCard);
+
+  let query = $state((card as SearchCard).data);
   let seenCache: { [id: string]: string[] } = {};
-  let results: NostrEvent[] = [];
+  let results = $state<NostrEvent[]>([]);
+  let searchReactions = $state<{ [aCoordinate: string]: NostrEvent[] }>({});
 
   // close handlers
   let uwrcancel: () => void;
   let search: SubCloser;
+  let reactionSub: SubCloser | null = null;
   let subs: SubCloser[] = [];
   let redirectTimeout: ReturnType<typeof setTimeout> | undefined;
   let redirected = false;
-
-  onMount(() => {
-    query = searchCard.data;
-  });
 
   onMount(() => {
     // we won't do any searches if we already have the results
@@ -60,6 +62,10 @@
     if (uwrcancel) uwrcancel();
     subs.forEach((sub) => sub.close());
     if (search) search.close();
+    if (reactionSub) {
+      reactionSub.close();
+      reactionSub = null;
+    }
     if (redirectTimeout) {
       clearTimeout(redirectTimeout);
       redirectTimeout = undefined;
@@ -81,8 +87,21 @@
       tried = true;
     }, 1500);
 
+    function getAuthoritativeScore(evt: NostrEvent): number {
+      const authorWoT = $wot[evt.pubkey] || 0;
+      const aCoordinate = `${wikiKind}:${evt.pubkey}:${getTagOr(evt, 'd')}`;
+      const reactions = searchReactions[aCoordinate] || [];
+      
+      const reactionsScore = reactions.reduce((sum, r) => {
+        const reactorWoT = $wot[r.pubkey] || 0;
+        return sum + 1 + reactorWoT;
+      }, 0);
+      
+      return authorWoT + reactionsScore;
+    }
+
     const update = debounce(() => {
-      // sort by exact matches first, then by wotness
+      // sort by exact matches first, then by authoritative score (WoT + reactions)
       let normalizedIdentifier = normalizeIdentifier(query);
       results = results.sort((a, b) => {
         if (
@@ -98,10 +117,61 @@
         ) {
           return 1;
         } else {
-          return ($wot[b.pubkey] || 0) - ($wot[a.pubkey] || 0);
+          return getAuthoritativeScore(b) - getAuthoritativeScore(a);
         }
       });
       seenCache = seenCache;
+
+      // Subscribe to reactions for all current results
+      if (reactionSub) {
+        reactionSub.close();
+      }
+      if (results.length > 0) {
+        const coordinates = results.map(r => `${wikiKind}:${r.pubkey}:${getTagOr(r, 'd')}`);
+        const queryRelays = unique($userWikiRelays, DEFAULT_SEARCH_RELAYS);
+        reactionSub = pool.subscribeMany(
+          queryRelays,
+          [
+            {
+              kinds: [reactionKind],
+              '#a': coordinates
+            }
+          ],
+          {
+            id: 'search-reactions-' + query,
+            onevent(evt) {
+              const targetA = evt.tags.find(([k]) => k === 'a')?.[1];
+              if (targetA && evt.content === '✅') {
+                const current = searchReactions[targetA] || [];
+                if (!current.some(r => r.id === evt.id)) {
+                  searchReactions = {
+                    ...searchReactions,
+                    [targetA]: [...current, evt]
+                  };
+                  // Re-sort results inline
+                  results = results.sort((a, b) => {
+                    if (
+                      !isTagQuery &&
+                      getTagOr(a, 'd') === normalizedIdentifier &&
+                      getTagOr(b, 'd') !== normalizedIdentifier
+                    ) {
+                      return -1;
+                    } else if (
+                      !isTagQuery &&
+                      getTagOr(b, 'd') === normalizedIdentifier &&
+                      getTagOr(a, 'd') !== normalizedIdentifier
+                    ) {
+                      return 1;
+                    } else {
+                      return getAuthoritativeScore(b) - getAuthoritativeScore(a);
+                    }
+                  });
+                }
+              }
+            }
+          }
+        );
+      }
     }, 500);
 
     const relaysFromPreferredAuthors = unique(
@@ -274,10 +344,10 @@
 
 <div class="mt-2 font-bold text-4xl">
   <!-- svelte-ignore a11y-no-static-element-interactions -->
-  "<span
-    on:dblclick={startEditing}
-    on:blur={finishedEditing}
-    on:keydown={preventKeys}
+  <span
+    ondblclick={startEditing}
+    onblur={finishedEditing}
+    onkeydown={preventKeys}
     contenteditable="plaintext-only"
     bind:textContent={query}
   ></span>"
@@ -291,7 +361,7 @@
       {results.length < 1 ? "Can't find this article." : "Didn't find what you were looking for?"}
     </p>
     <button
-      on:click={() => {
+      onclick={() => {
         replaceSelf({ id: next(), type: 'editor', data: { title: query, summary: '', content: '', previous: card } });
       }}
       class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
@@ -299,7 +369,7 @@
       Create this article!
     </button>
     <button
-      on:click={() => createChild({ id: next(), type: 'settings' })}
+      onclick={() => createChild({ id: next(), type: 'settings' })}
       class="ml-1 inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
     >
       Add more relays

--- a/src/cards/Search.svelte
+++ b/src/cards/Search.svelte
@@ -74,6 +74,9 @@
     results = [];
     redirected = false;
 
+    const isTagQuery = query.startsWith('#');
+    const tagTerm = isTagQuery ? query.substring(1).toLowerCase().trim() : '';
+
     setTimeout(() => {
       tried = true;
     }, 1500);
@@ -83,11 +86,13 @@
       let normalizedIdentifier = normalizeIdentifier(query);
       results = results.sort((a, b) => {
         if (
+          !isTagQuery &&
           getTagOr(a, 'd') === normalizedIdentifier &&
           getTagOr(b, 'd') !== normalizedIdentifier
         ) {
           return -1;
         } else if (
+          !isTagQuery &&
           getTagOr(b, 'd') === normalizedIdentifier &&
           getTagOr(a, 'd') !== normalizedIdentifier
         ) {
@@ -129,15 +134,19 @@
 
       if (relaysToUseNow.length === 0) return;
 
+      const exactFilter = isTagQuery
+        ? { kinds: [wikiKind], '#t': [tagTerm], limit: 25 }
+        : { kinds: [wikiKind], '#d': [normalizeIdentifier(query)], limit: 25 };
+
       let subc = pool.subscribeMany(
         relaysToUseNow,
-        [{ kinds: [wikiKind], '#d': [normalizeIdentifier(query)], limit: 25 }],
+        [exactFilter],
         {
           id: 'find-exactmatch',
           onevent(evt) {
             tried = true;
 
-            if (searchCard.preferredAuthors.includes(evt.pubkey)) {
+            if (!isTagQuery && searchCard.preferredAuthors.includes(evt.pubkey)) {
               // we found an exact match that fits the list of preferred authors
               // jump straight into it
               redirected = true;
@@ -149,7 +158,7 @@
               update();
 
               // If we have not redirected yet, check if this is an exact match and schedule a fallback redirect
-              if (!redirected && getTagOr(evt, 'd') === normalizeIdentifier(query)) {
+              if (!isTagQuery && !redirected && getTagOr(evt, 'd') === normalizeIdentifier(query)) {
                 if (!redirectTimeout) {
                   redirectTimeout = setTimeout(() => {
                     if (redirected) return;

--- a/src/cards/Search.svelte
+++ b/src/cards/Search.svelte
@@ -292,10 +292,12 @@
         type: 'article',
         data: [getTagOr(result, 'd'), result.pubkey],
         relayHints: seenCache[result.id],
-        actualEvent: result,
+        actualEvent: { ...result, tags: result.tags.map(t => [...t]) },
         versions:
           getTagOr(result, 'd') === normalizeIdentifier(query)
-            ? results.filter((evt) => getTagOr(evt, 'd') === normalizeIdentifier(query))
+            ? results
+                .filter((evt) => getTagOr(evt, 'd') === normalizeIdentifier(query))
+                .map((evt) => ({ ...evt, tags: evt.tags.map((t) => [...t]) }))
             : undefined
       };
       if (ev?.button === 1) createChild(articleCard);

--- a/src/cards/Search.svelte
+++ b/src/cards/Search.svelte
@@ -349,7 +349,7 @@
 </script>
 
 <div class="mt-2 font-bold text-4xl">
-  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <span
     ondblclick={startEditing}
     onblur={finishedEditing}

--- a/src/cards/Search.svelte
+++ b/src/cards/Search.svelte
@@ -146,8 +146,35 @@
           onevent(evt) {
             tried = true;
 
+            const shouldRedirect = searchCard.redirect !== false;
+
+            if (shouldRedirect && !isTagQuery && searchCard.preferredAuthors.includes(evt.pubkey)) {
+              // we found an exact match that fits the list of preferred authors
+              // jump straight into it
+              redirected = true;
+              if (redirectTimeout) clearTimeout(redirectTimeout);
+              openArticle(evt, undefined, true);
+            }
+
             if (addUniqueTaggedReplaceable(results, evt)) {
               update();
+
+              // If we have not redirected yet, check if this is an exact match and schedule a fallback redirect
+              if (shouldRedirect && !isTagQuery && !redirected && getTagOr(evt, 'd') === normalizeIdentifier(query)) {
+                if (!redirectTimeout) {
+                  redirectTimeout = setTimeout(() => {
+                    if (redirected) return;
+                    // Find the best exact match from results (sorted by WoT)
+                    const exactMatches = results.filter(
+                      (r) => getTagOr(r, 'd') === normalizeIdentifier(query)
+                    );
+                    if (exactMatches.length > 0) {
+                      redirected = true;
+                      openArticle(exactMatches[0], undefined, true);
+                    }
+                  }, 800);
+                }
+              }
             }
           },
           oneose,
@@ -237,6 +264,7 @@
       // update stored card state
       searchCard.data = normalizeIdentifier(query);
       searchCard.results = undefined;
+      searchCard.redirect = false;
 
       // redo the query
       debouncedPerformSearch();

--- a/src/cards/Search.svelte
+++ b/src/cards/Search.svelte
@@ -30,6 +30,7 @@
 
   let searchCard = $derived(card as SearchCard);
 
+  // svelte-ignore state_referenced_locally
   let query = $state((card as SearchCard).data);
   let seenCache: { [id: string]: string[] } = {};
   let results = $state<NostrEvent[]>([]);

--- a/src/cards/Settings.svelte
+++ b/src/cards/Settings.svelte
@@ -1,14 +1,119 @@
 <script lang="ts">
-  function saveData() {}
+  import { onMount } from 'svelte';
+  import { DEFAULT_WIKI_RELAYS } from '$lib/defaults';
+
+  let customRelays = $state<string[]>([]);
+  let newRelay = $state('');
+
+  onMount(() => {
+    const stored = localStorage.getItem('wikistr:custom-relays');
+    if (stored) {
+      try {
+        customRelays = JSON.parse(stored);
+      } catch (e) {
+        customRelays = [];
+      }
+    }
+  });
+
+  function addRelay() {
+    const url = newRelay.trim();
+    if (!url) return;
+    if (!url.startsWith('wss://') && !url.startsWith('ws://')) {
+      alert('Relay URL must start with wss:// or ws://');
+      return;
+    }
+    if (customRelays.includes(url)) {
+      alert('Relay already added');
+      return;
+    }
+    customRelays = [...customRelays, url];
+    newRelay = '';
+  }
+
+  function removeRelay(url: string) {
+    customRelays = customRelays.filter((r) => r !== url);
+  }
+
+  function saveData() {
+    localStorage.setItem('wikistr:custom-relays', JSON.stringify(customRelays));
+    window.location.reload();
+  }
 </script>
 
-<div class="mt-2 font-bold text-4xl">Settings</div>
+<div class="p-6 max-w-xl mx-auto bg-white rounded-xl shadow-md space-y-6 border border-stone-100">
+  <div>
+    <h2 class="text-2xl font-bold text-stone-900">Configure Relays</h2>
+    <p class="text-sm text-stone-500 mt-1">
+      Add or remove custom Nostr relays used to read and publish wiki articles.
+    </p>
+  </div>
 
-<!-- Save button -->
-<button
-  onclick={saveData}
-  type="button"
-  class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
->
-  Save & Reload
-</button>
+  <!-- Add Relay Form -->
+  <div class="space-y-2">
+    <label for="relay-url" class="block text-sm font-medium text-stone-700">Add Custom Relay</label>
+    <div class="flex gap-2">
+      <input
+        id="relay-url"
+        type="text"
+        placeholder="wss://relay.example.com"
+        bind:value={newRelay}
+        onkeydown={(e) => e.key === 'Enter' && addRelay()}
+        class="flex-1 min-w-0 block w-full px-3 py-2 rounded-md border border-stone-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+      />
+      <button
+        onclick={addRelay}
+        type="button"
+        class="inline-flex items-center px-4 py-2 border border-stone-300 text-sm font-medium rounded-md shadow-sm text-stone-700 bg-white hover:bg-stone-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+      >
+        Add
+      </button>
+    </div>
+  </div>
+
+  <!-- Custom Relays List -->
+  <div class="space-y-3">
+    <h3 class="text-sm font-semibold text-stone-800 uppercase tracking-wider">Your Custom Relays</h3>
+    {#if customRelays.length === 0}
+      <div class="text-sm text-stone-400 italic py-2">No custom relays configured. Default relays will be used.</div>
+    {:else}
+      <div class="divide-y divide-stone-100 max-h-60 overflow-y-auto pr-1 border border-stone-100 rounded-md">
+        {#each customRelays as url}
+          <div class="flex items-center justify-between py-2.5 px-3 hover:bg-stone-50 transition-colors">
+            <span class="text-sm font-mono text-stone-600 truncate mr-4">{url}</span>
+            <button
+              onclick={() => removeRelay(url)}
+              type="button"
+              class="text-xs font-semibold text-rose-600 hover:text-rose-800 transition-colors"
+            >
+              Remove
+            </button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+
+  <!-- Default Relays Reference -->
+  <div class="space-y-2 pt-2 border-t border-stone-100">
+    <h3 class="text-xs font-semibold text-stone-400 uppercase tracking-wider">Default Relays (Active if no custom)</h3>
+    <div class="flex flex-wrap gap-1.5">
+      {#each DEFAULT_WIKI_RELAYS as url}
+        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-stone-100 text-stone-800 font-mono">
+          {url.replace('wss://', '')}
+        </span>
+      {/each}
+    </div>
+  </div>
+
+  <!-- Save actions -->
+  <div class="pt-4 border-t border-stone-100 flex justify-end">
+    <button
+      onclick={saveData}
+      type="button"
+      class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-semibold rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
+    >
+      Save & Reload
+    </button>
+  </div>
+</div>

--- a/src/cards/User.svelte
+++ b/src/cards/User.svelte
@@ -3,7 +3,7 @@
   import debounce from 'debounce';
   import type { NostrEvent } from '@nostr/tools/pure';
 
-  import type { ArticleCard, Card } from '$lib/types';
+  import type { ArticleCard, UserCard, Card } from '$lib/types';
   import { addUniqueTaggedReplaceable, getTagOr, next } from '$lib/utils';
   import { wikiKind } from '$lib/nostr';
   import ArticleListItem from '$components/ArticleListItem.svelte';
@@ -11,7 +11,7 @@
   import { subscribeOutbox } from '$lib/outbox';
 
   interface Props {
-    card: Card;
+    card: UserCard;
     createChild: (card: Card) => void;
   }
 
@@ -37,11 +37,11 @@
         limit: 50
       },
       {
-        receivedEvent(relay, id) {
+        receivedEvent(relay: any, id: string) {
           if (!(id in seenCache)) seenCache[id] = [];
           if (seenCache[id].indexOf(relay.url) === -1) seenCache[id].push(relay.url);
         },
-        onevent(evt) {
+        onevent(evt: NostrEvent) {
           if (addUniqueTaggedReplaceable(results, evt)) update();
         }
       }

--- a/src/cards/Welcome.svelte
+++ b/src/cards/Welcome.svelte
@@ -1,27 +1,12 @@
 <script lang="ts">
-  import debounce from 'debounce';
-  import { onDestroy } from 'svelte';
-  import type { SubCloser } from '@nostr/tools/abstract-pool';
-  import type { AbstractRelay } from '@nostr/tools/abstract-relay';
-  import type { Event, NostrEvent } from '@nostr/tools/pure';
-
   import {
     signer,
-    wikiKind,
     account,
-    wot,
-    getBasicUserWikiRelays,
     userWikiRelays
   } from '$lib/nostr';
   import type { ArticleCard, Card } from '$lib/types';
-  import { addUniqueTaggedReplaceable, getTagOr, next } from '$lib/utils';
-  import { subscribeAllOutbox } from '$lib/outbox';
-  import ArticleListItem from '$components/ArticleListItem.svelte';
+  import { next, urlWithoutScheme } from '$lib/utils';
   import { onMount } from 'svelte';
-  import RelayItem from '$components/RelayItem.svelte';
-  import { DEFAULT_WIKI_RELAYS } from '$lib/defaults';
-  import { pool } from '@nostr/gadgets/global';
-  import { urlWithoutScheme } from '$lib/utils';
   import New from './New.svelte';
   import { fetchPrivateTagsFromRelays } from '$lib/privateTagsSync';
 
@@ -30,7 +15,6 @@
   }
 
   let { createChild }: Props = $props();
-  let seenCache: { [id: string]: string[] } = {};
 
   let pinnedList = $state<{ dTag: string; pubkey: string; title: string }[]>([]);
   let historyList = $state<{ dTag: string; pubkey: string; title: string; timestamp: number }[]>([]);
@@ -113,116 +97,12 @@
     };
   });
 
-  let results = $state<Event[]>([]);
-  const feeds = [normalFeed, followsFeed];
-  let current = $state(0);
-
-  const update = debounce(() => {
-    // sort by an average of newness and wotness
-    results.sort((a, b) => {
-      const wotA = $wot[a.pubkey] || 0;
-      const wotB = $wot[b.pubkey] || 0;
-      let wotAvg = (wotA + wotB) / 2 || 1;
-      let tsAvg = (a.created_at + b.created_at) / 2;
-      return wotB / wotAvg + b.created_at / tsAvg - (wotA / wotAvg + a.created_at / tsAvg);
-    });
-    results = results;
-    seenCache = seenCache;
-  }, 500);
-
-  let close = () => {};
-
-  onDestroy(() => {
-    close();
-  });
-
   function doLogin() {
     signer.getPublicKey();
   }
 
-  function openArticle(result: Event) {
-    createChild({
-      id: next(),
-      type: 'article',
-      data: [getTagOr(result, 'd'), result.pubkey],
-      actualEvent: result,
-      relayHints: seenCache[result.id] || []
-    } as ArticleCard);
-  }
-
   function replaceNewCard(newCard: Card) {
     createChild(newCard);
-  }
-
-  function restart() {
-    close();
-    results = [];
-    close = feeds[current]();
-  }
-
-  setTimeout(restart, 400);
-
-  function normalFeed() {
-    let sub: SubCloser | undefined;
-    let cancel = account.subscribe(async (account) => {
-      if (sub) sub.close();
-
-      sub = pool.subscribeMany(
-        account ? await getBasicUserWikiRelays(account.pubkey) : DEFAULT_WIKI_RELAYS,
-        [
-          {
-            kinds: [wikiKind],
-            limit: 15
-          }
-        ],
-        {
-          id: 'recent',
-          onevent,
-          receivedEvent
-        }
-      );
-    });
-
-    return () => {
-      if (sub) sub.close();
-      cancel();
-    };
-  }
-
-  function followsFeed() {
-    let exited = false;
-
-    let subc: SubCloser;
-    let wotsubclose = wot.subscribe((wot) => {
-      if (exited) {
-        return;
-      }
-
-      const eligibleKeys = Object.entries(wot)
-        .filter(([_, v]) => v > 170)
-        .map(([k]) => k);
-
-      subc = subscribeAllOutbox(
-        eligibleKeys,
-        { kinds: [wikiKind], limit: 20 },
-        { id: 'alloutbox', onevent, receivedEvent }
-      );
-    });
-
-    return () => {
-      exited = true;
-      wotsubclose();
-      subc?.close?.();
-    };
-  }
-
-  function onevent(evt: NostrEvent) {
-    if (addUniqueTaggedReplaceable(results, evt)) update();
-  }
-
-  function receivedEvent(relay: any, id: string) {
-    if (!(id in seenCache)) seenCache[id] = [];
-    if (seenCache[id].indexOf(relay.url) === -1) seenCache[id].push(relay.url);
   }
 </script>
 
@@ -237,22 +117,6 @@
         <p class="w-64 text-ellipsis overflow-hidden">{$account.npub}</p>
         <p>{$account.shortName}</p>
       </div>
-    </div>
-    <div class="mt-2">
-      <button
-        onclick={() => {
-          current = (current + 1) % feeds.length;
-          restart();
-        }}
-        type="submit"
-        class="inline-flex items-center space-x-2 px-3 py-2 border border-gray-300 text-sm font-medium rounded-md bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 text-white"
-      >
-        {#if feeds[current] === normalFeed}
-          Browse articles from contacts
-        {:else if feeds[current] === followsFeed}
-          Browse articles from your relays
-        {/if}
-      </button>
     </div>
   {:else}
     <button
@@ -395,19 +259,3 @@
   {/if}
 </div>
 
-<div class="mb-2 font-bold text-4xl">
-  {#if feeds[current] === normalFeed}
-    Recent Articles
-    <div class="flex items-center flex-wrap">
-      <div class="mr-1 font-normal text-xs">from</div>
-      {#each $userWikiRelays as url}
-        <RelayItem {url} {createChild} />
-      {/each}
-    </div>
-  {:else if feeds[current] === followsFeed}
-    Articles from Contacts
-  {/if}
-</div>
-{#each results as result (result.id)}
-  <ArticleListItem event={result} {openArticle} />
-{/each}

--- a/src/cards/Welcome.svelte
+++ b/src/cards/Welcome.svelte
@@ -20,6 +20,7 @@
   import RelayItem from '$components/RelayItem.svelte';
   import { DEFAULT_WIKI_RELAYS } from '$lib/defaults';
   import { pool } from '@nostr/gadgets/global';
+  import New from './New.svelte';
 
   interface Props {
     createChild: (card: Card) => void;
@@ -63,6 +64,10 @@
       actualEvent: result,
       relayHints: seenCache[result.id] || []
     } as ArticleCard);
+  }
+
+  function replaceNewCard(newCard: Card) {
+    createChild(newCard);
   }
 
   function restart() {
@@ -173,6 +178,10 @@
       >Login</button
     >
   {/if}
+</div>
+
+<div class="my-6 p-4 border border-stone-200 rounded-lg bg-stone-50/50">
+  <New {replaceNewCard} />
 </div>
 
 <div class="mb-2 font-bold text-4xl">

--- a/src/cards/Welcome.svelte
+++ b/src/cards/Welcome.svelte
@@ -34,6 +34,40 @@
   let pinnedList = $state<{ dTag: string; pubkey: string; title: string }[]>([]);
   let historyList = $state<{ dTag: string; pubkey: string; title: string; timestamp: number }[]>([]);
   let showRelays = $state(false);
+  let privateTagsMap = $state<{ [tag: string]: { dTag: string; pubkey: string; title: string }[] }>({});
+  let activePrivateTag = $state<string | null>(null);
+
+  function loadPrivateTagsMap() {
+    try {
+      const stored = localStorage.getItem('wikistr:private-tags');
+      const allPrivateTags = stored ? JSON.parse(stored) : {};
+      
+      const storedPinned = localStorage.getItem('wikistr:pinned');
+      const pinned = storedPinned ? JSON.parse(storedPinned) : [];
+      const storedHistory = localStorage.getItem('wikistr:history');
+      const history = storedHistory ? JSON.parse(storedHistory) : [];
+      const allItems = [...pinned, ...history];
+      
+      const map: typeof privateTagsMap = {};
+      
+      Object.entries(allPrivateTags).forEach(([key, tags]) => {
+        const [pubkey, dTag] = key.split(':');
+        const match = allItems.find((x) => x.dTag === dTag && x.pubkey === pubkey);
+        const title = match ? match.title : dTag;
+        
+        if (Array.isArray(tags)) {
+          tags.forEach((tag) => {
+            if (!map[tag]) map[tag] = [];
+            map[tag].push({ dTag, pubkey, title });
+          });
+        }
+      });
+      
+      privateTagsMap = map;
+    } catch (e) {
+      console.error(e);
+    }
+  }
 
   function loadDashboardData() {
     try {
@@ -44,6 +78,8 @@
       const storedHistory = localStorage.getItem('wikistr:history');
       historyList = storedHistory ? JSON.parse(storedHistory) : [];
       if (!Array.isArray(historyList)) historyList = [];
+
+      loadPrivateTagsMap();
     } catch (e) {
       console.error(e);
     }
@@ -268,6 +304,43 @@
         </button>
       {/each}
     </div>
+  </div>
+{/if}
+
+{#if Object.keys(privateTagsMap).length > 0}
+  <div class="my-6 p-4 border border-stone-200 rounded-lg bg-stone-50/50">
+    <h2 class="font-bold text-lg text-stone-700 mb-3 flex items-center space-x-2">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5 text-amber-500">
+        <path fill-rule="evenodd" d="M12 1.5a5.25 5.25 0 0 0-5.25 5.25v3a3 3 0 0 0-3 3v6.75a3 3 0 0 0 3 3h10.5a3 3 0 0 0 3-3v-6.75a3 3 0 0 0-3-3v-3c0-2.9-2.35-5.25-5.25-5.25Zm3.75 8.25v-3a3.75 3.75 0 1 0-7.5 0v3h7.5Z" clip-rule="evenodd" />
+      </svg>
+      <span>Your Private Tags</span>
+    </h2>
+    <div class="flex flex-wrap gap-1.5 mb-3">
+      {#each Object.keys(privateTagsMap) as tag}
+        <button 
+          onclick={() => activePrivateTag = activePrivateTag === tag ? null : tag}
+          class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold border transition-all {activePrivateTag === tag ? 'bg-amber-100 text-amber-800 border-amber-300 shadow-sm' : 'bg-white text-stone-600 border-stone-200 hover:bg-stone-50'}"
+        >
+          #{tag} ({privateTagsMap[tag].length})
+        </button>
+      {/each}
+    </div>
+    
+    {#if activePrivateTag && privateTagsMap[activePrivateTag]}
+      <div class="space-y-2 border-t border-stone-200/60 pt-3">
+        {#each privateTagsMap[activePrivateTag] as item}
+          <button 
+            onclick={() => openArticleByCoordinate(item.dTag, item.pubkey)}
+            class="w-full text-left p-2 rounded bg-white border border-stone-100 hover:border-indigo-300 hover:shadow-sm transition-all text-xs font-medium text-stone-700 flex items-center justify-between"
+          >
+            <span class="truncate">{item.title}</span>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3.5 h-3.5 text-stone-400">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+            </svg>
+          </button>
+        {/each}
+      </div>
+    {/if}
   </div>
 {/if}
 

--- a/src/cards/Welcome.svelte
+++ b/src/cards/Welcome.svelte
@@ -220,7 +220,7 @@
     if (addUniqueTaggedReplaceable(results, evt)) update();
   }
 
-  function receivedEvent(relay: AbstractRelay, id: string) {
+  function receivedEvent(relay: any, id: string) {
     if (!(id in seenCache)) seenCache[id] = [];
     if (seenCache[id].indexOf(relay.url) === -1) seenCache[id].push(relay.url);
   }

--- a/src/cards/Welcome.svelte
+++ b/src/cards/Welcome.svelte
@@ -17,9 +17,11 @@
   import { addUniqueTaggedReplaceable, getTagOr, next } from '$lib/utils';
   import { subscribeAllOutbox } from '$lib/outbox';
   import ArticleListItem from '$components/ArticleListItem.svelte';
+  import { onMount } from 'svelte';
   import RelayItem from '$components/RelayItem.svelte';
   import { DEFAULT_WIKI_RELAYS } from '$lib/defaults';
   import { pool } from '@nostr/gadgets/global';
+  import { urlWithoutScheme } from '$lib/utils';
   import New from './New.svelte';
 
   interface Props {
@@ -28,6 +30,41 @@
 
   let { createChild }: Props = $props();
   let seenCache: { [id: string]: string[] } = {};
+
+  let pinnedList = $state<{ dTag: string; pubkey: string; title: string }[]>([]);
+  let historyList = $state<{ dTag: string; pubkey: string; title: string; timestamp: number }[]>([]);
+  let showRelays = $state(false);
+
+  function loadDashboardData() {
+    try {
+      const storedPinned = localStorage.getItem('wikistr:pinned');
+      pinnedList = storedPinned ? JSON.parse(storedPinned) : [];
+      if (!Array.isArray(pinnedList)) pinnedList = [];
+
+      const storedHistory = localStorage.getItem('wikistr:history');
+      historyList = storedHistory ? JSON.parse(storedHistory) : [];
+      if (!Array.isArray(historyList)) historyList = [];
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  function openArticleByCoordinate(dTag: string, pubkey: string) {
+    createChild({
+      id: next(),
+      type: 'article',
+      data: [dTag, pubkey],
+      relayHints: []
+    } as ArticleCard);
+  }
+
+  onMount(() => {
+    loadDashboardData();
+    window.addEventListener('storage', loadDashboardData);
+    return () => {
+      window.removeEventListener('storage', loadDashboardData);
+    };
+  });
 
   let results = $state<Event[]>([]);
   const feeds = [normalFeed, followsFeed];
@@ -182,6 +219,96 @@
 
 <div class="my-6 p-4 border border-stone-200 rounded-lg bg-stone-50/50">
   <New {replaceNewCard} />
+</div>
+
+{#if pinnedList.length > 0}
+  <div class="my-6 p-4 border border-stone-200 rounded-lg bg-stone-50/50">
+    <h2 class="font-bold text-lg text-stone-700 mb-3 flex items-center space-x-2">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="#eab308" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-amber-500">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
+      </svg>
+      <span>Pinned Pages</span>
+    </h2>
+    <div class="space-y-2">
+      {#each pinnedList as pin}
+        <button 
+          onclick={() => openArticleByCoordinate(pin.dTag, pin.pubkey)}
+          class="w-full text-left p-2 rounded bg-white border border-stone-100 hover:border-indigo-300 hover:shadow-sm transition-all text-sm font-medium text-stone-800 flex items-center justify-between"
+        >
+          <span class="truncate">{pin.title}</span>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-stone-400">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+          </svg>
+        </button>
+      {/each}
+    </div>
+  </div>
+{/if}
+
+{#if historyList.length > 0}
+  <div class="my-6 p-4 border border-stone-200 rounded-lg bg-stone-50/50">
+    <h2 class="font-bold text-lg text-stone-700 mb-3 flex items-center space-x-2">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-indigo-500">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+      </svg>
+      <span>Recently Viewed</span>
+    </h2>
+    <div class="space-y-2">
+      {#each historyList as hist}
+        <button 
+          onclick={() => openArticleByCoordinate(hist.dTag, hist.pubkey)}
+          class="w-full text-left p-2 rounded bg-white border border-stone-100 hover:border-indigo-300 hover:shadow-sm transition-all text-sm font-medium text-stone-800 flex items-center justify-between"
+        >
+          <span class="truncate">{hist.title}</span>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-stone-400">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+          </svg>
+        </button>
+      {/each}
+    </div>
+  </div>
+{/if}
+
+<div class="my-6 p-4 border border-stone-200 rounded-lg bg-stone-50/50">
+  <button 
+    onclick={() => showRelays = !showRelays}
+    class="flex items-center justify-between w-full font-bold text-lg text-stone-700 focus:outline-none"
+  >
+    <span class="flex items-center space-x-2">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-indigo-500">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699-2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z" />
+      </svg>
+      <span>Relays ({$userWikiRelays.length})</span>
+    </span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 transform transition-transform {showRelays ? 'rotate-180' : ''}">
+      <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+    </svg>
+  </button>
+  
+  {#if showRelays}
+    <div class="mt-4 space-y-2 max-h-48 overflow-y-auto scrollbar-thin">
+      {#each $userWikiRelays as url}
+        <div class="flex items-center justify-between p-2 rounded bg-white border border-stone-100 hover:bg-stone-50 text-sm">
+          <span class="font-mono text-stone-600 truncate mr-2">{urlWithoutScheme(url)}</span>
+          <div class="flex items-center space-x-1.5 flex-shrink-0">
+            <span class="w-2.5 h-2.5 rounded-full bg-emerald-500 shadow-sm" title="Connected"></span>
+            <button 
+              onclick={() => createChild({ id: next(), type: 'relay', data: url })}
+              class="text-xs text-indigo-600 hover:underline"
+            >
+              Details
+            </button>
+          </div>
+        </div>
+      {/each}
+      <button 
+        onclick={() => createChild({ id: next(), type: 'settings' })}
+        class="w-full text-center py-1.5 mt-2 text-xs font-semibold text-indigo-600 hover:text-indigo-800 border border-dashed border-indigo-200 rounded hover:border-indigo-400 bg-indigo-50/20 transition-all"
+      >
+        Configure Relays
+      </button>
+    </div>
+  {/if}
 </div>
 
 <div class="mb-2 font-bold text-4xl">

--- a/src/cards/Welcome.svelte
+++ b/src/cards/Welcome.svelte
@@ -61,8 +61,10 @@
   onMount(() => {
     loadDashboardData();
     window.addEventListener('storage', loadDashboardData);
+    window.addEventListener('wikistr:dashboard-update', loadDashboardData);
     return () => {
       window.removeEventListener('storage', loadDashboardData);
+      window.removeEventListener('wikistr:dashboard-update', loadDashboardData);
     };
   });
 

--- a/src/cards/Welcome.svelte
+++ b/src/cards/Welcome.svelte
@@ -23,6 +23,7 @@
   import { pool } from '@nostr/gadgets/global';
   import { urlWithoutScheme } from '$lib/utils';
   import New from './New.svelte';
+  import { fetchPrivateTagsFromRelays } from '$lib/privateTagsSync';
 
   interface Props {
     createChild: (card: Card) => void;
@@ -98,9 +99,17 @@
     loadDashboardData();
     window.addEventListener('storage', loadDashboardData);
     window.addEventListener('wikistr:dashboard-update', loadDashboardData);
+    
+    const unsubAccount = account.subscribe((acc) => {
+      if (acc) {
+        fetchPrivateTagsFromRelays(acc.pubkey);
+      }
+    });
+
     return () => {
       window.removeEventListener('storage', loadDashboardData);
       window.removeEventListener('wikistr:dashboard-update', loadDashboardData);
+      unsubAccount();
     };
   });
 

--- a/src/components/ArticleContent.svelte
+++ b/src/components/ArticleContent.svelte
@@ -16,7 +16,7 @@
   let { event, createChild }: Props = $props();
 
   let authorPreferredWikiAuthors = $state<string[]>([]);
-  const content = appendLinkMacroToNostrLinks(turnWikilinksIntoAsciidocLinks(event.content));
+  const content = $derived(appendLinkMacroToNostrLinks(turnWikilinksIntoAsciidocLinks(event.content)));
 
   onMount(() => {
     loadWikiAuthors(event.pubkey).then((ps) => {

--- a/src/components/ArticleContent.svelte
+++ b/src/components/ArticleContent.svelte
@@ -6,7 +6,7 @@
 
   import WikilinkComponent from './WikilinkComponent.svelte';
   import type { Card } from '$lib/types';
-  import { turnWikilinksIntoAsciidocLinks } from '$lib/utils';
+  import { turnWikilinksIntoAsciidocLinks, appendLinkMacroToNostrLinks } from '$lib/utils';
 
   interface Props {
     event: NostrEvent;
@@ -16,7 +16,7 @@
   let { event, createChild }: Props = $props();
 
   let authorPreferredWikiAuthors = $state<string[]>([]);
-  const content = turnWikilinksIntoAsciidocLinks(event.content);
+  const content = appendLinkMacroToNostrLinks(turnWikilinksIntoAsciidocLinks(event.content));
 
   onMount(() => {
     loadWikiAuthors(event.pubkey).then((ps) => {

--- a/src/components/ArticleListItem.svelte
+++ b/src/components/ArticleListItem.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
   import type { NostrEvent } from '@nostr/tools/pure';
+  import { onMount } from 'svelte';
+  import { pool } from '@nostr/gadgets/global';
+  import { reactionKind, wikiKind } from '$lib/nostr';
+  import { DEFAULT_SEARCH_RELAYS } from '$lib/defaults';
 
   import UserLabel from './UserLabel.svelte';
   import { formatDate } from '$lib/utils';
@@ -10,6 +14,9 @@
   }
 
   let { openArticle, event }: Props = $props();
+
+  let reactionEvents = $state<NostrEvent[]>([]);
+  let authoritativeCount = $derived(reactionEvents.filter(r => r.content === '✅').length);
 
   let plainText = $derived(
     event.content
@@ -23,6 +30,28 @@
   function handleClick(ev: MouseEvent) {
     openArticle(event, ev);
   }
+
+  onMount(() => {
+    const dTag = event.tags.find((e) => e[0] === 'd')?.[1];
+    if (!dTag) return;
+    const sub = pool.subscribeMany(
+      DEFAULT_SEARCH_RELAYS,
+      [
+        {
+          kinds: [reactionKind],
+          '#a': [`${wikiKind}:${event.pubkey}:${dTag}`]
+        }
+      ],
+      {
+        onevent(evt) {
+          if (!reactionEvents.some(r => r.id === evt.id)) {
+            reactionEvents = [...reactionEvents, evt];
+          }
+        }
+      }
+    );
+    return () => sub.close();
+  });
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
@@ -30,10 +59,20 @@
   onmouseup={handleClick}
   class="cursor-pointer p-4 bg-white border-2 border-stone-200 hover:bg-stone-50 rounded-lg mt-2"
 >
-  <h1>
-    {event.tags.find((e) => e[0] == 'title')?.[0] && event.tags.find((e) => e[0] == 'title')?.[1]
-      ? event.tags.find((e) => e[0] == 'title')?.[1]
-      : event.tags.find((e) => e[0] == 'd')?.[1]}
+  <h1 class="flex items-center gap-1.5 font-bold text-lg">
+    <span>
+      {event.tags.find((e) => e[0] == 'title')?.[0] && event.tags.find((e) => e[0] == 'title')?.[1]
+        ? event.tags.find((e) => e[0] == 'title')?.[1]
+        : event.tags.find((e) => e[0] == 'd')?.[1]}
+    </span>
+    {#if authoritativeCount > 0}
+      <span class="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-bold rounded bg-emerald-100 text-emerald-800 border border-emerald-200" title={`${authoritativeCount} users marked this as authoritative`}>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-3 h-3 text-emerald-600">
+          <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z" clip-rule="evenodd" />
+        </svg>
+        <span>{authoritativeCount}</span>
+      </span>
+    {/if}
   </h1>
   <p class="text-xs my-1">
     by&nbsp;<span class="-ml-1"><UserLabel pubkey={event.pubkey} /></span>

--- a/src/components/ArticleListItem.svelte
+++ b/src/components/ArticleListItem.svelte
@@ -28,7 +28,11 @@
   );
 
   function handleClick(ev: MouseEvent) {
-    openArticle(event, ev);
+    try {
+      openArticle(event, ev);
+    } catch (err) {
+      alert("Error opening article: " + err);
+    }
   }
 
   onMount(() => {

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -16,9 +16,11 @@
 
   interface Props {
     card: Card;
+    collapsed?: boolean;
+    onToggleCollapse?: () => void;
   }
 
-  let { card }: Props = $props();
+  let { card, collapsed = false, onToggleCollapse }: Props = $props();
 
   function close() {
     if (card.type === 'editor' && card.data.previous) replaceSelf(card.data.previous);
@@ -110,7 +112,6 @@
   }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
 <div
   id={`wikicard-${card.id}`}
   class="
@@ -118,12 +119,15 @@
   overflow-x-hidden
   mx-2 mt-2
   w-[calc(100vw_-_24px)] min-w-[calc(100vw_-_24px)] max-w-[calc(100vw_-_24px)]
-  {card.type === 'article' || card.type === 'editor'
-    ? 'sm:min-w-[500px] sm:max-w-[500px] lg:min-w-[48rem] lg:max-w-[48rem] xl:min-w-[56rem] xl:max-w-[56rem]' 
-    : 'sm:min-w-[395px] sm:max-w-[395px] lg:min-w-[32rem] lg:max-w-[32rem]'}
+  {collapsed 
+    ? 'sm:min-w-[64px] sm:max-w-[64px] sm:overflow-hidden' 
+    : card.type === 'article' || card.type === 'editor'
+      ? 'sm:min-w-[500px] sm:max-w-[500px] lg:min-w-[48rem] lg:max-w-[48rem] xl:min-w-[56rem] xl:max-w-[56rem]' 
+      : 'sm:min-w-[395px] sm:max-w-[395px] lg:min-w-[32rem] lg:max-w-[32rem]'}
   rounded-lg border-8 bg-white
   h-[calc(100vh_-_32px)]
-  p-4
+  {collapsed ? 'sm:p-2 p-4' : 'p-4'}
+  transition-all duration-300
   scrollbar-thin scrollbar-thumb-stone-300 scrollbar-track-stone-100 hover:scrollbar-thumb-stone-400"
   ondblclick={scrollIntoViewIfNecessary}
   style:border-color={card.type === 'article'
@@ -132,50 +136,87 @@
       ? hashbow(card.data, 88)
       : '#e5e7eb'}
 >
-  {#if card.type !== 'welcome' && card.type !== 'new'}
-    <div class="flex" class:justify-between={card.back} class:justify-end={!card.back}>
-      {#if card.back}
-        <button aria-label="back" onclick={back}>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="w-6 h-6 stroke-stone-500"
-            viewBox="0 0 219.151 219.151"
-          >
-            <path
-              d="M94.861,156.507c2.929,2.928,7.678,2.927,10.606,0c2.93-2.93,2.93-7.678-0.001-10.608l-28.82-28.819l83.457-0.008 c4.142-0.001,7.499-3.358,7.499-7.502c-0.001-4.142-3.358-7.498-7.5-7.498l-83.46,0.008l28.827-28.825 c2.929-2.929,2.929-7.679,0-10.607c-1.465-1.464-3.384-2.197-5.304-2.197c-1.919,0-3.838,0.733-5.303,2.196l-41.629,41.628 c-1.407,1.406-2.197,3.313-2.197,5.303c0.001,1.99,0.791,3.896,2.198,5.305L94.861,156.507z"
-            ></path>
+  {#if collapsed}
+    <!-- Collapsed vertical view on desktop -->
+    <div class="hidden sm:flex flex-col items-center justify-start h-full pt-2 space-y-8 select-none">
+      <button 
+        onclick={onToggleCollapse}
+        class="p-1.5 rounded-md hover:bg-stone-100 text-stone-600 transition-colors"
+        title="Expand welcome column"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 4.5l7.5 7.5-7.5 7.5M4.5 4.5l7.5 7.5-7.5 7.5" />
+        </svg>
+      </button>
+      <div class="text-stone-400 font-bold tracking-widest text-xs uppercase whitespace-nowrap rotate-180" style="writing-mode: vertical-lr;">
+        Welcome & Search
+      </div>
+    </div>
+    <!-- Mobile view fallback -->
+    <div class="sm:hidden flex justify-between items-center mb-4">
+      <div class="font-bold text-lg">Welcome</div>
+      <button onclick={onToggleCollapse} class="p-1 text-stone-600 hover:bg-stone-100 rounded text-sm">Expand</button>
+    </div>
+  {:else}
+    {#if card.type === 'welcome' && onToggleCollapse}
+      <div class="hidden sm:flex justify-end mb-2">
+        <button 
+          onclick={onToggleCollapse}
+          class="p-1 rounded-md hover:bg-stone-100 text-stone-500 transition-colors"
+          title="Collapse welcome column"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M18.75 19.5l-7.5-7.5 7.5-7.5M12 19.5l-7.5-7.5 7.5-7.5" />
           </svg>
         </button>
-      {/if}
-      <button aria-label="close" onclick={close}>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          class="w-6 h-6 stroke-stone-800"
-          viewBox="0 0 24 24"
-          stroke-width="1.5"
-          ><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg
-        >
-      </button>
-    </div>
-  {/if}
-  <article class="font-sans mx-auto p-2 lg:max-w-4xl">
-    {#if card.type === 'article'}
-      <Article {createChild} {replaceSelf} {back} {card} />
-    {:else if card.type === 'new'}
-      <New {replaceNewCard} />
-    {:else if card.type === 'find'}
-      <Search {createChild} {replaceSelf} {card} />
-    {:else if card.type === 'welcome'}
-      <Welcome {createChild} />
-    {:else if card.type === 'relay'}
-      <Relay {createChild} {replaceSelf} {card} />
-    {:else if card.type === 'user'}
-      <User {createChild} {card} />
-    {:else if card.type === 'settings'}
-      <Settings />
-    {:else if card.type === 'editor'}
-      <Editor {replaceSelf} {card} />
+      </div>
     {/if}
-  </article>
+
+    {#if card.type !== 'welcome' && card.type !== 'new'}
+      <div class="flex" class:justify-between={card.back} class:justify-end={!card.back}>
+        {#if card.back}
+          <button aria-label="back" onclick={back}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="w-6 h-6 stroke-stone-500"
+              viewBox="0 0 219.151 219.151"
+            >
+              <path
+                d="M94.861,156.507c2.929,2.928,7.678,2.927,10.606,0c2.93-2.93,2.93-7.678-0.001-10.608l-28.82-28.819l83.457-0.008 c4.142-0.001,7.499-3.358,7.499-7.502c-0.001-4.142-3.358-7.498-7.5-7.498l-83.46,0.008l28.827-28.825 c2.929-2.929,2.929-7.679,0-10.607c-1.465-1.464-3.384-2.197-5.304-2.197c-1.919,0-3.838,0.733-5.303,2.196l-41.629,41.628 c-1.407,1.406-2.197,3.313-2.197,5.303c0.001,1.99,0.791,3.896,2.198,5.305L94.861,156.507z"
+              ></path>
+            </svg>
+          </button>
+        {/if}
+        <button aria-label="close" onclick={close}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            class="w-6 h-6 stroke-stone-800"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            ><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg
+          >
+        </button>
+      </div>
+    {/if}
+    <article class="font-sans mx-auto p-2 lg:max-w-4xl">
+      {#if card.type === 'article'}
+        <Article {createChild} {replaceSelf} {back} {card} />
+      {:else if card.type === 'new'}
+        <New {replaceNewCard} />
+      {:else if card.type === 'find'}
+        <Search {createChild} {replaceSelf} {card} />
+      {:else if card.type === 'welcome'}
+        <Welcome {createChild} />
+      {:else if card.type === 'relay'}
+        <Relay {createChild} {replaceSelf} {card} />
+      {:else if card.type === 'user'}
+        <User {createChild} {card} />
+      {:else if card.type === 'settings'}
+        <Settings />
+      {:else if card.type === 'editor'}
+        <Editor {replaceSelf} {card} />
+      {/if}
+    </article>
+  {/if}
 </div>

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -126,8 +126,7 @@
       ? 'sm:min-w-[500px] sm:max-w-[500px] lg:min-w-[48rem] lg:max-w-[48rem] xl:min-w-[56rem] xl:max-w-[56rem]' 
       : 'sm:min-w-[395px] sm:max-w-[395px] lg:min-w-[32rem] lg:max-w-[32rem]'}
   rounded-lg border-8 bg-white
-  h-[calc(100vh_-_32px)]
-  {collapsed ? 'sm:p-2 p-4' : 'p-4'}
+  {collapsed ? 'sm:h-[calc(100vh_-_32px)] h-auto sm:p-2 p-4' : 'h-[calc(100vh_-_32px)] p-4'}
   transition-all duration-300
   scrollbar-thin scrollbar-thumb-stone-300 scrollbar-track-stone-100 hover:scrollbar-thumb-stone-400"
   ondblclick={scrollIntoViewIfNecessary}
@@ -158,18 +157,24 @@
       </div>
     </div>
     <!-- Mobile view fallback -->
-    <div class="sm:hidden flex justify-between items-center mb-4">
-      <div class="font-bold text-lg">
+    <div class="sm:hidden flex justify-between items-center">
+      <div class="font-bold text-lg text-stone-700">
         {#if card.type === 'welcome'}
-          Welcome
+          Welcome & Search
         {:else if card.type === 'recent'}
           Recent Articles
         {/if}
       </div>
-      <button onclick={onToggleCollapse} class="p-1 text-stone-600 hover:bg-stone-100 rounded text-sm">Expand</button>
+      <button 
+        onclick={onToggleCollapse} 
+        class="px-2.5 py-1 text-xs font-semibold text-indigo-600 bg-indigo-50 border border-indigo-200 rounded hover:bg-indigo-100 hover:text-indigo-800 transition-colors"
+      >
+        Expand
+      </button>
     </div>
   {:else}
     {#if (card.type === 'welcome' || card.type === 'recent') && onToggleCollapse}
+      <!-- Desktop collapse button -->
       <div class="hidden sm:flex justify-end mb-2">
         <button 
           onclick={onToggleCollapse}
@@ -179,6 +184,22 @@
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M18.75 19.5l-7.5-7.5 7.5-7.5M12 19.5l-7.5-7.5 7.5-7.5" />
           </svg>
+        </button>
+      </div>
+      <!-- Mobile collapse header -->
+      <div class="sm:hidden flex justify-between items-center mb-4 pb-2 border-b border-stone-100">
+        <div class="font-bold text-lg text-stone-700">
+          {#if card.type === 'welcome'}
+            Welcome & Search
+          {:else if card.type === 'recent'}
+            Recent Articles
+          {/if}
+        </div>
+        <button 
+          onclick={onToggleCollapse} 
+          class="px-2.5 py-1 text-xs font-semibold text-stone-600 bg-stone-50 border border-stone-200 rounded hover:bg-stone-100 transition-colors"
+        >
+          Collapse
         </button>
       </div>
     {/if}

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -114,6 +114,7 @@
 </script>
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
+  role="presentation"
   id={`wikicard-${card.id}`}
   class="
   overflow-y-auto

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -98,7 +98,7 @@
   function toURL(card: Card): string | null {
     switch (card.type) {
       case 'find':
-        return encodeURIComponent(card.data);
+        return encodeURIComponent(encodeURIComponent(card.data));
       case 'article':
         return card.data.join('*');
       case 'relay':

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -112,7 +112,7 @@
     return null;
   }
 </script>
-
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   id={`wikicard-${card.id}`}
   class="

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -108,6 +108,8 @@
         return npubEncode(card.data);
       case 'editor':
         return 'edit:' + (card as EditorCard).data.title;
+      case 'settings':
+        return 'settings';
     }
     return null;
   }

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -98,7 +98,7 @@
   function toURL(card: Card): string | null {
     switch (card.type) {
       case 'find':
-        return card.data;
+        return encodeURIComponent(card.data);
       case 'article':
         return card.data.join('*');
       case 'relay':

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -167,9 +167,12 @@
       </div>
       <button 
         onclick={onToggleCollapse} 
-        class="px-2.5 py-1 text-xs font-semibold text-indigo-600 bg-indigo-50 border border-indigo-200 rounded hover:bg-indigo-100 hover:text-indigo-800 transition-colors"
+        class="p-1.5 text-indigo-600 hover:bg-indigo-50 border border-indigo-200 rounded transition-colors"
+        title={card.type === 'welcome' ? 'Expand welcome column' : 'Expand recent articles column'}
       >
-        Expand
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="w-4 h-4">
+          <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+        </svg>
       </button>
     </div>
   {:else}
@@ -197,9 +200,12 @@
         </div>
         <button 
           onclick={onToggleCollapse} 
-          class="px-2.5 py-1 text-xs font-semibold text-stone-600 bg-stone-50 border border-stone-200 rounded hover:bg-stone-100 transition-colors"
+          class="p-1.5 text-stone-600 hover:bg-stone-50 border border-stone-200 rounded transition-colors"
+          title={card.type === 'welcome' ? 'Collapse welcome column' : 'Collapse recent articles column'}
         >
-          Collapse
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="w-4 h-4">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
+          </svg>
         </button>
       </div>
     {/if}

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -117,7 +117,7 @@
   overflow-y-auto
   overflow-x-hidden
   mx-2 mt-2
-  min-w-[395px] max-w-[395px] lg:min-w-[32rem] lg:max-w-[32rem]
+  w-[calc(100vw_-_24px)] min-w-[calc(100vw_-_24px)] max-w-[calc(100vw_-_24px)] sm:min-w-[395px] sm:max-w-[395px] lg:min-w-[32rem] lg:max-w-[32rem]
   rounded-lg border-8 bg-white
   h-[calc(100vh_-_32px)]
   p-4

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -8,6 +8,7 @@
   import Article from '$cards/Article.svelte';
   import Editor from '$cards/Editor.svelte';
   import Welcome from '$cards/Welcome.svelte';
+  import Recent from '$cards/Recent.svelte';
   import Search from '$cards/Search.svelte';
   import Settings from '$cards/Settings.svelte';
   import Relay from '$cards/Relay.svelte';
@@ -142,28 +143,38 @@
       <button 
         onclick={onToggleCollapse}
         class="p-1.5 rounded-md hover:bg-stone-100 text-stone-600 transition-colors"
-        title="Expand welcome column"
+        title={card.type === 'welcome' ? 'Expand welcome column' : 'Expand recent articles column'}
       >
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 4.5l7.5 7.5-7.5 7.5M4.5 4.5l7.5 7.5-7.5 7.5" />
         </svg>
       </button>
       <div class="text-stone-400 font-bold tracking-widest text-xs uppercase whitespace-nowrap rotate-180" style="writing-mode: vertical-lr;">
-        Welcome & Search
+        {#if card.type === 'welcome'}
+          Welcome & Search
+        {:else if card.type === 'recent'}
+          Recent Articles
+        {/if}
       </div>
     </div>
     <!-- Mobile view fallback -->
     <div class="sm:hidden flex justify-between items-center mb-4">
-      <div class="font-bold text-lg">Welcome</div>
+      <div class="font-bold text-lg">
+        {#if card.type === 'welcome'}
+          Welcome
+        {:else if card.type === 'recent'}
+          Recent Articles
+        {/if}
+      </div>
       <button onclick={onToggleCollapse} class="p-1 text-stone-600 hover:bg-stone-100 rounded text-sm">Expand</button>
     </div>
   {:else}
-    {#if card.type === 'welcome' && onToggleCollapse}
+    {#if (card.type === 'welcome' || card.type === 'recent') && onToggleCollapse}
       <div class="hidden sm:flex justify-end mb-2">
         <button 
           onclick={onToggleCollapse}
           class="p-1 rounded-md hover:bg-stone-100 text-stone-500 transition-colors"
-          title="Collapse welcome column"
+          title={card.type === 'welcome' ? 'Collapse welcome column' : 'Collapse recent articles column'}
         >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M18.75 19.5l-7.5-7.5 7.5-7.5M12 19.5l-7.5-7.5 7.5-7.5" />
@@ -172,7 +183,7 @@
       </div>
     {/if}
 
-    {#if card.type !== 'welcome' && card.type !== 'new'}
+    {#if card.type !== 'welcome' && card.type !== 'new' && card.type !== 'recent'}
       <div class="flex" class:justify-between={card.back} class:justify-end={!card.back}>
         {#if card.back}
           <button aria-label="back" onclick={back}>
@@ -208,6 +219,8 @@
         <Search {createChild} {replaceSelf} {card} />
       {:else if card.type === 'welcome'}
         <Welcome {createChild} />
+      {:else if card.type === 'recent'}
+        <Recent {createChild} />
       {:else if card.type === 'relay'}
         <Relay {createChild} {replaceSelf} {card} />
       {:else if card.type === 'user'}

--- a/src/components/CardElement.svelte
+++ b/src/components/CardElement.svelte
@@ -117,7 +117,10 @@
   overflow-y-auto
   overflow-x-hidden
   mx-2 mt-2
-  w-[calc(100vw_-_24px)] min-w-[calc(100vw_-_24px)] max-w-[calc(100vw_-_24px)] sm:min-w-[395px] sm:max-w-[395px] lg:min-w-[32rem] lg:max-w-[32rem]
+  w-[calc(100vw_-_24px)] min-w-[calc(100vw_-_24px)] max-w-[calc(100vw_-_24px)]
+  {card.type === 'article' || card.type === 'editor'
+    ? 'sm:min-w-[500px] sm:max-w-[500px] lg:min-w-[48rem] lg:max-w-[48rem] xl:min-w-[56rem] xl:max-w-[56rem]' 
+    : 'sm:min-w-[395px] sm:max-w-[395px] lg:min-w-[32rem] lg:max-w-[32rem]'}
   rounded-lg border-8 bg-white
   h-[calc(100vh_-_32px)]
   p-4

--- a/src/components/WikilinkComponent.svelte
+++ b/src/components/WikilinkComponent.svelte
@@ -11,10 +11,11 @@
 
   let { attrs, children }: Props = $props();
 
-  const { href } = attrs;
+  // Make href reactive via derived
+  let href = $derived(attrs.href || '');
 
-  // svelte-ignore non_reactive_update
-  let wikitarget = href.substring(9); // Remove 'wikilink:' prefix
+  // Derived wikitarget
+  let wikitarget = $derived(href.startsWith('wikilink:') ? href.substring(9) : href);
 
   const extra: undefined | { preferredAuthors: string[]; createChild: (card: Card) => void } =
     getExtra();
@@ -23,24 +24,22 @@
     createChild: undefined
   };
 
-  if (href.startsWith('wikilink:')) {
-    wikitarget = href.substring(9);
-  }
-
-  let isNaddr = false;
-  let naddrData: any = null;
-
-  if (href && href.startsWith('nostr:naddr1')) {
-    try {
-      const decoded = decode(href.replace('nostr:', ''));
-      if (decoded.type === 'naddr') {
-        isNaddr = true;
-        naddrData = decoded.data;
+  // Derived naddr data
+  let decodedNaddr = $derived.by(() => {
+    if (href && href.startsWith('nostr:naddr1')) {
+      try {
+        const decoded = decode(href.replace('nostr:', ''));
+        if (decoded.type === 'naddr') {
+          return decoded.data;
+        }
+      } catch (e) {
+        console.error('Failed to decode naddr:', e);
       }
-    } catch (e) {
-      console.error('Failed to decode naddr:', e);
     }
-  }
+    return null;
+  });
+
+  let isNaddr = $derived(decodedNaddr !== null);
 
   function handleWikilinkClick() {
     if (createChild) {
@@ -49,12 +48,12 @@
   }
 
   function handleNaddrClick() {
-    if (createChild && naddrData) {
+    if (createChild && decodedNaddr) {
       createChild({
         id: next(),
         type: 'article',
-        data: [naddrData.identifier, naddrData.pubkey],
-        relayHints: naddrData.relays || []
+        data: [decodedNaddr.identifier, decodedNaddr.pubkey],
+        relayHints: decodedNaddr.relays || []
       });
     }
   }
@@ -67,10 +66,10 @@
     onclick={handleWikilinkClick}>{@render children?.()}</button
   >
 {:else}
-  {#if isNaddr}
+  {#if isNaddr && decodedNaddr}
     <button
       class="text-indigo-600 underline"
-      title={`nostr link to: "${naddrData.identifier}"`}
+      title={`nostr link to: "${decodedNaddr.identifier}"`}
       onclick={handleNaddrClick}>{@render children?.()}</button
     >
   {:else}

--- a/src/components/WikilinkComponent.svelte
+++ b/src/components/WikilinkComponent.svelte
@@ -28,7 +28,7 @@
 
   function handleWikilinkClick() {
     if (createChild) {
-      createChild({ id: next(), type: 'find', data: wikitarget, preferredAuthors } as SearchCard);
+      createChild({ id: next(), type: 'find', data: wikitarget, preferredAuthors, redirect: true } as SearchCard);
     }
   }
 </script>

--- a/src/components/WikilinkComponent.svelte
+++ b/src/components/WikilinkComponent.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { decode } from '@nostr/tools/nip19';
   import type { SearchCard, Card } from '$lib/types';
   import { next } from '$lib/utils';
   import { getExtra } from 'svelte-asciidoc';
@@ -26,9 +27,35 @@
     wikitarget = href.substring(9);
   }
 
+  let isNaddr = false;
+  let naddrData: any = null;
+
+  if (href && href.startsWith('nostr:naddr1')) {
+    try {
+      const decoded = decode(href.replace('nostr:', ''));
+      if (decoded.type === 'naddr') {
+        isNaddr = true;
+        naddrData = decoded.data;
+      }
+    } catch (e) {
+      console.error('Failed to decode naddr:', e);
+    }
+  }
+
   function handleWikilinkClick() {
     if (createChild) {
       createChild({ id: next(), type: 'find', data: wikitarget, preferredAuthors, redirect: true } as SearchCard);
+    }
+  }
+
+  function handleNaddrClick() {
+    if (createChild && naddrData) {
+      createChild({
+        id: next(),
+        type: 'article',
+        data: [naddrData.identifier, naddrData.pubkey],
+        relayHints: naddrData.relays || []
+      });
     }
   }
 </script>
@@ -40,25 +67,33 @@
     onclick={handleWikilinkClick}>{@render children?.()}</button
   >
 {:else}
-  <!-- svelte-ignore a11y_missing_attribute -->
-  <a target="_blank" {...attrs}>
-    {@render children?.()}
-    <svg
-      class="align-text-top h-3.5 inline pl-1"
-      viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      ><g stroke-linecap="round" stroke-linejoin="round"></g><g>
-        <g>
-          <path
-            d="M10.0002 5H8.2002C7.08009 5 6.51962 5 6.0918 5.21799C5.71547 5.40973 5.40973 5.71547 5.21799 6.0918C5 6.51962 5 7.08009 5 8.2002V15.8002C5 16.9203 5 17.4801 5.21799 17.9079C5.40973 18.2842 5.71547 18.5905 6.0918 18.7822C6.5192 19 7.07899 19 8.19691 19H15.8031C16.921 19 17.48 19 17.9074 18.7822C18.2837 18.5905 18.5905 18.2839 18.7822 17.9076C19 17.4802 19 16.921 19 15.8031V14M20 9V4M20 4H15M20 4L13 11"
-            stroke="#000000"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          ></path>
-        </g>
-      </g></svg
+  {#if isNaddr}
+    <button
+      class="text-indigo-600 underline"
+      title={`nostr link to: "${naddrData.identifier}"`}
+      onclick={handleNaddrClick}>{@render children?.()}</button
     >
-  </a>
+  {:else}
+    <!-- svelte-ignore a11y_missing_attribute -->
+    <a target="_blank" {...attrs}>
+      {@render children?.()}
+      <svg
+        class="align-text-top h-3.5 inline pl-1"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        ><g stroke-linecap="round" stroke-linejoin="round"></g><g>
+          <g>
+            <path
+              d="M10.0002 5H8.2002C7.08009 5 6.51962 5 6.0918 5.21799C5.71547 5.40973 5.40973 5.71547 5.21799 6.0918C5 6.51962 5 7.08009 5 8.2002V15.8002C5 16.9203 5 17.4801 5.21799 17.9079C5.40973 18.2842 5.71547 18.5905 6.0918 18.7822C6.5192 19 7.07899 19 8.19691 19H15.8031C16.921 19 17.48 19 17.9074 18.7822C18.2837 18.5905 18.5905 18.2839 18.7822 17.9076C19 17.4802 19 16.921 19 15.8031V14M20 9V4M20 4H15M20 4L13 11"
+              stroke="#000000"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            ></path>
+          </g>
+        </g></svg
+      >
+    </a>
+  {/if}
 {/if}

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -1,0 +1,46 @@
+export interface DiffLine {
+  type: 'added' | 'removed' | 'unmodified';
+  value: string;
+}
+
+/**
+ * Computes a line-by-line diff between two strings using the Longest Common Subsequence (LCS) algorithm.
+ */
+export function diffLines(oldStr: string, newStr: string): DiffLine[] {
+  const oldLines = oldStr.split(/\r?\n/);
+  const newLines = newStr.split(/\r?\n/);
+
+  const dp: number[][] = Array(oldLines.length + 1)
+    .fill(null)
+    .map(() => Array(newLines.length + 1).fill(0));
+
+  for (let i = 1; i <= oldLines.length; i++) {
+    for (let j = 1; j <= newLines.length; j++) {
+      if (oldLines[i - 1] === newLines[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  const result: DiffLine[] = [];
+  let i = oldLines.length;
+  let j = newLines.length;
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+      result.unshift({ type: 'unmodified', value: oldLines[i - 1] });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      result.unshift({ type: 'added', value: newLines[j - 1] });
+      j--;
+    } else if (i > 0 && (j === 0 || dp[i][j - 1] < dp[i - 1][j])) {
+      result.unshift({ type: 'removed', value: oldLines[i - 1] });
+      i--;
+    }
+  }
+
+  return result;
+}

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -17,6 +17,7 @@ const startTime = Math.round(Date.now() / 1000);
 
 export const reactionKind = 7;
 export const wikiKind = 30818;
+export const gitPatchKind = 1617;
 
 export const signer = {
   getPublicKey: async () => {

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -31,6 +31,14 @@ export const signer = {
     const se: Event = await (window as any).nostr.signEvent(event);
     setAccount(se.pubkey);
     return se;
+  },
+  encrypt: async (pubkey: string, plaintext: string): Promise<string> => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return await (window as any).nostr.nip04.encrypt(pubkey, plaintext);
+  },
+  decrypt: async (pubkey: string, ciphertext: string): Promise<string> => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return await (window as any).nostr.nip04.decrypt(pubkey, ciphertext);
   }
 };
 

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -110,24 +110,51 @@ wot.subscribe(() => {});
 export const userWikiRelays = derived(
   account,
   (account, set) => {
-    account ? getBasicUserWikiRelays(account.pubkey).then(set) : set(DEFAULT_WIKI_RELAYS);
+    if (account) {
+      getBasicUserWikiRelays(account.pubkey).then(set);
+    } else {
+      let customRelays: string[] = [];
+      if (typeof window !== 'undefined') {
+        const customStored = localStorage.getItem('wikistr:custom-relays');
+        if (customStored) {
+          try {
+            customRelays = JSON.parse(customStored);
+          } catch (e) {}
+        }
+      }
+      set(unique(customRelays, DEFAULT_WIKI_RELAYS));
+    }
   },
   DEFAULT_WIKI_RELAYS
 );
 
 export async function getBasicUserWikiRelays(pubkey: string): Promise<string[]> {
-  const [rl1, rl2] = await Promise.all([
-    loadWikiRelays(pubkey).then((rl) => rl.items),
-    Promise.all((await loadWikiAuthors(pubkey)).items.map((pk) => loadRelayList(pk))).then((rll) =>
+  let customRelays: string[] = [];
+  if (typeof window !== 'undefined') {
+    const customStored = localStorage.getItem('wikistr:custom-relays');
+    if (customStored) {
+      try {
+        customRelays = JSON.parse(customStored);
+      } catch (e) {}
+    }
+  }
+
+  const [rl1, rl2, rl3] = await Promise.all([
+    loadWikiRelays(pubkey).then((rl) => rl.items).catch(() => []),
+    Promise.all((await loadWikiAuthors(pubkey).catch(() => ({ items: [] }))).items.map((pk) => loadRelayList(pk).catch(() => null))).then((rll) =>
       rll
+        .filter((rl): rl is Exclude<typeof rl, null> => rl !== null)
         .map((rl) => rl.items)
         .flat()
         .filter((ri) => ri.write)
         .map((ri) => ri.url)
-    )
+    ).catch(() => []),
+    loadRelayList(pubkey).then((rl) =>
+      rl.items.filter((ri) => ri.write).map((ri) => ri.url)
+    ).catch(() => [])
   ]);
 
-  let list = unique(rl1, rl2);
+  let list = unique(customRelays, rl1, rl2, rl3);
   if (list.length < 2) {
     list = unique(list, DEFAULT_WIKI_RELAYS);
   }

--- a/src/lib/outbox.ts
+++ b/src/lib/outbox.ts
@@ -7,7 +7,7 @@ import { outboxFilterRelayBatch } from '@nostr/gadgets/outbox';
 export function subscribeAllOutbox(
   pubkeys: string[],
   baseFilter: Omit<Filter, 'authors'> & { limit: number },
-  params: SubscribeManyParams
+  params: any
 ): SubCloser {
   let closed = false;
   let subc: SubCloser;
@@ -32,7 +32,7 @@ export function subscribeAllOutbox(
 export function subscribeOutbox(
   pubkey: string,
   baseFilter: Omit<Filter, 'authors'> & { limit: number },
-  params: SubscribeManyParams
+  params: any
 ): SubCloser {
   let closed = false;
   let subc: SubCloser;

--- a/src/lib/privateTagsSync.ts
+++ b/src/lib/privateTagsSync.ts
@@ -1,0 +1,117 @@
+import type { Event, EventTemplate } from '@nostr/tools/pure';
+import { pool } from '@nostr/gadgets/global';
+import { signer, wikiKind, getBasicUserWikiRelays } from './nostr';
+
+export async function fetchPrivateTagsFromRelays(pubkey: string): Promise<void> {
+  try {
+    const relays = await getBasicUserWikiRelays(pubkey);
+    let latestEvent: Event | null = null;
+
+    await new Promise<void>((resolve) => {
+      const sub = pool.subscribeMany(
+        relays,
+        [
+          {
+            kinds: [30003],
+            authors: [pubkey],
+            '#d': ['wikistr-private-tags']
+          }
+        ],
+        {
+          id: 'fetch-private-tags',
+          onevent(evt) {
+            if (!latestEvent || evt.created_at > latestEvent.created_at) {
+              latestEvent = evt;
+            }
+          },
+          oneose() {
+            sub.close();
+            resolve();
+          }
+        }
+      );
+      // Timeout fallback in case relays are unresponsive
+      setTimeout(() => {
+        sub.close();
+        resolve();
+      }, 3500);
+    });
+
+    if (latestEvent) {
+      const ciphertext = (latestEvent as Event).content;
+      if (!ciphertext) return;
+
+      const plaintext = await signer.decrypt(pubkey, ciphertext);
+      const parsed = JSON.parse(plaintext);
+      
+      if (Array.isArray(parsed)) {
+        const privateTagsMap: { [key: string]: string[] } = {};
+        
+        parsed.forEach((tagArray) => {
+          if (Array.isArray(tagArray) && tagArray[0] === 'a') {
+            const coord = tagArray[1]; // e.g. "30818:pubkey:dtag"
+            const label = tagArray[3]; // tag name
+            
+            if (coord && label && coord.startsWith(`${wikiKind}:`)) {
+              // Strip "30818:" prefix to get "pubkey:dtag"
+              const key = coord.substring(`${wikiKind}:`.length);
+              if (!privateTagsMap[key]) {
+                privateTagsMap[key] = [];
+              }
+              if (!privateTagsMap[key].includes(label)) {
+                privateTagsMap[key].push(label);
+              }
+            }
+          }
+        });
+        
+        localStorage.setItem('wikistr:private-tags', JSON.stringify(privateTagsMap));
+        window.dispatchEvent(new Event('wikistr:dashboard-update'));
+      }
+    }
+  } catch (e) {
+    console.error('Failed to sync private tags from relays', e);
+  }
+}
+
+export async function publishPrivateTagsToRelays(pubkey: string): Promise<void> {
+  try {
+    const stored = localStorage.getItem('wikistr:private-tags');
+    const allPrivateTags = stored ? JSON.parse(stored) : {};
+    
+    const bookmarksArray: string[][] = [];
+    Object.entries(allPrivateTags).forEach(([key, list]) => {
+      if (Array.isArray(list)) {
+        list.forEach((tag) => {
+          bookmarksArray.push(['a', `${wikiKind}:${key}`, '', tag]);
+        });
+      }
+    });
+
+    const encryptedContent = await signer.encrypt(pubkey, JSON.stringify(bookmarksArray));
+    const relays = await getBasicUserWikiRelays(pubkey);
+
+    const eventTemplate: EventTemplate = {
+      kind: 30003,
+      tags: [['d', 'wikistr-private-tags']],
+      content: encryptedContent,
+      created_at: Math.round(Date.now() / 1000)
+    };
+
+    const signedEvent = await signer.signEvent(eventTemplate);
+    
+    // Publish to all write relays
+    await Promise.all(
+      relays.map(async (url) => {
+        try {
+          const r = await pool.ensureRelay(url);
+          await r.publish(signedEvent);
+        } catch (err) {
+          console.error(`Failed to publish private tags to relay ${url}`, err);
+        }
+      })
+    );
+  } catch (e) {
+    console.error('Failed to publish private tags to relays', e);
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ export type EditorData = {
   title: string;
   summary: string;
   content: string;
+  tags?: string[];
   previous: Card | undefined;
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -32,6 +32,8 @@ export function serializeCardForRouter(card: Card) {
     case 'article':
       if (serialized.actualEvent)
         serialized.actualEvent = eventOutFromProxy(serialized.actualEvent);
+      if (serialized.versions)
+        serialized.versions = [...serialized.versions].map(eventOutFromProxy);
       break;
     case 'editor':
       if (serialized.data && serialized.data.previous) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,7 +4,7 @@ export type EditorData = {
   title: string;
   summary: string;
   content: string;
-  previous: ArticleCard | undefined;
+  previous: Card | undefined;
 };
 
 export type Card =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -33,6 +33,14 @@ export function serializeCardForRouter(card: Card) {
       if (serialized.actualEvent)
         serialized.actualEvent = eventOutFromProxy(serialized.actualEvent);
       break;
+    case 'editor':
+      if (serialized.data && serialized.data.previous) {
+        serialized.data = {
+          ...serialized.data,
+          previous: serializeCardForRouter(serialized.data.previous)
+        };
+      }
+      break;
   }
 
   return serialized;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,6 +10,7 @@ export type EditorData = {
 
 export type Card =
   | WelcomeCard
+  | RecentCard
   | NewCard
   | SearchCard
   | ArticleCard
@@ -55,6 +56,12 @@ function eventOutFromProxy(event: NostrEvent): NostrEvent {
 export type WelcomeCard = {
   id: number;
   type: 'welcome';
+  back?: Card;
+};
+
+export type RecentCard = {
+  id: number;
+  type: 'recent';
   back?: Card;
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -62,6 +62,7 @@ export type SearchCard = {
   preferredAuthors: string[];
   results?: NostrEvent[];
   seenCache?: { [id: string]: string[] };
+  redirect?: boolean;
 };
 
 export type ArticleCard = {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -20,10 +20,10 @@
   let prevCardsLength = 0;
 
   $effect(() => {
-    if ($cards.length < 2) {
+    if ($cards.length < 1) {
       isWelcomeCollapsed = false;
-    } else if ($cards.length >= 2 && prevCardsLength < 2) {
-      isWelcomeCollapsed = true; // Auto-collapse when second column is opened
+    } else if ($cards.length >= 1 && prevCardsLength < 1) {
+      isWelcomeCollapsed = true; // Auto-collapse when first column is opened
     }
     prevCardsLength = $cards.length;
   });
@@ -83,7 +83,7 @@
 <div class="flex overflow-x-scroll pb-2" draggable="false" bind:this={slider}>
   <CardElement 
     card={{ type: 'welcome', id: -1 }} 
-    collapsed={$cards.length >= 2 && isWelcomeCollapsed}
+    collapsed={$cards.length >= 1 && isWelcomeCollapsed}
     onToggleCollapse={() => isWelcomeCollapsed = !isWelcomeCollapsed}
   />
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,6 +16,18 @@
   let scrollLeft: number;
   let slider: HTMLElement;
 
+  let isWelcomeCollapsed = $state(false);
+  let prevCardsLength = 0;
+
+  $effect(() => {
+    if ($cards.length < 2) {
+      isWelcomeCollapsed = false;
+    } else if ($cards.length >= 2 && prevCardsLength < 2) {
+      isWelcomeCollapsed = true; // Auto-collapse when second column is opened
+    }
+    prevCardsLength = $cards.length;
+  });
+
   onMount(() => {
     document.addEventListener('mousedown', onMouseDown);
     document.addEventListener('mouseup', onMouseUp);
@@ -69,7 +81,11 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
 <div class="flex overflow-x-scroll pb-2" draggable="false" bind:this={slider}>
-  <CardElement card={{ type: 'welcome', id: -1 }} />
+  <CardElement 
+    card={{ type: 'welcome', id: -1 }} 
+    collapsed={$cards.length >= 2 && isWelcomeCollapsed}
+    onToggleCollapse={() => isWelcomeCollapsed = !isWelcomeCollapsed}
+  />
 
   {#each $cards as card (card.id)}
     <CardElement {card} />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -77,6 +77,4 @@
 
   <!-- this is just empty -->
   {@render children?.()}
-
-  <CardElement card={{ type: 'new', id: -1 }} />
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,13 +17,16 @@
   let slider: HTMLElement;
 
   let isWelcomeCollapsed = $state(false);
+  let isRecentCollapsed = $state(false);
   let prevCardsLength = 0;
 
   $effect(() => {
     if ($cards.length < 1) {
       isWelcomeCollapsed = false;
+      isRecentCollapsed = false;
     } else if ($cards.length >= 1 && prevCardsLength < 1) {
       isWelcomeCollapsed = true; // Auto-collapse when first column is opened
+      isRecentCollapsed = true;
     }
     prevCardsLength = $cards.length;
   });
@@ -85,6 +88,12 @@
     card={{ type: 'welcome', id: -1 }} 
     collapsed={$cards.length >= 1 && isWelcomeCollapsed}
     onToggleCollapse={() => isWelcomeCollapsed = !isWelcomeCollapsed}
+  />
+
+  <CardElement 
+    card={{ type: 'recent', id: -2 }} 
+    collapsed={$cards.length >= 1 && isRecentCollapsed}
+    onToggleCollapse={() => isRecentCollapsed = !isRecentCollapsed}
   />
 
   {#each $cards as card (card.id)}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -83,7 +83,7 @@
 </svelte:head>
 
 <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
-<div class="flex overflow-x-scroll pb-2" draggable="false" bind:this={slider}>
+<div class="flex flex-col sm:flex-row sm:overflow-x-scroll pb-2" draggable="false" bind:this={slider}>
   <CardElement 
     card={{ type: 'welcome', id: -1 }} 
     collapsed={$cards.length >= 1 && isWelcomeCollapsed}

--- a/src/routes/[...path]/+page.svelte
+++ b/src/routes/[...path]/+page.svelte
@@ -27,7 +27,7 @@
 
   $effect(() => {
     let prevP: string[] = [];
-    let nextP = page.params.path.split('/').filter((str) => str !== '');
+    let nextP = (page.params.path || '').split('/').filter((str) => str !== '');
 
     let nextCards: Card[] = [];
     for (let n = 0; n < nextP.length; n++) {

--- a/src/routes/[...path]/+page.svelte
+++ b/src/routes/[...path]/+page.svelte
@@ -83,7 +83,7 @@
     } else if (pathPart.match(/^[\w-]+\*[a-f0-9]{64}$/)) {
       return { id: next(), type: 'article', data: pathPart.split('*') } as ArticleCard;
     } else {
-      return { id: next(), type: 'find', data: pathPart, preferredAuthors: [] } as SearchCard;
+      return { id: next(), type: 'find', data: ditem, preferredAuthors: [] } as SearchCard;
     }
   }
 </script>

--- a/src/routes/[...path]/+page.svelte
+++ b/src/routes/[...path]/+page.svelte
@@ -83,7 +83,7 @@
     } else if (pathPart.match(/^[\w-]+\*[a-f0-9]{64}$/)) {
       return { id: next(), type: 'article', data: pathPart.split('*') } as ArticleCard;
     } else {
-      return { id: next(), type: 'find', data: ditem, preferredAuthors: [] } as SearchCard;
+      return { id: next(), type: 'find', data: ditem, preferredAuthors: [], redirect: true } as SearchCard;
     }
   }
 </script>

--- a/src/routes/[...path]/+page.svelte
+++ b/src/routes/[...path]/+page.svelte
@@ -66,7 +66,9 @@
 
   function cardFromPathPart(pathPart: string): Card {
     let ditem = decodeURIComponent(pathPart);
-    if (ditem.startsWith('edit:')) {
+    if (ditem === 'settings') {
+      return { id: next(), type: 'settings' };
+    } else if (ditem.startsWith('edit:')) {
       return {
         id: next(),
         type: 'editor',


### PR DESCRIPTION
This PR introduces several major enhancements and bug fixes to the Wikistr client:

1. **Wiki Article Features**:
   - Collapsible welcome column layout with a Wiki Dashboard (pinned pages, reading history, connected relays status).
   - In-editor inline article lookup and link insertion helper.
   - Sidebar with page size, revisions, contributors count, and first published date.
   - Responsive, full-width Table of Contents.
   - Git-like Fork & Pull-Request suggestion workflow (NIP-34 Kind 1617 Git Patches).

2. **Tagging & Private Bookmarks**:
   - NIP-51 encrypted private tag syncing on Nostr relays.
   - User-private bookmarks/tags on articles and dashboard filter view.
   - Categories/tags creation, search, and presentation in Articles and Editor.

3. **Link Routing & Performance Optimizations**:
   - In-app routing for `nostr:naddr` wikilinks to directly open referenced articles instead of external browser tabs or search pages.
   - Cached relay fetches, shared subscription lists, and lazy-loading of discussion and history tabs.

4. **Deterministic Version Tracking & Caching**:
   - Automatic version detection and incrementing when editing, adding a `['version', String(version)]` tag to the published event.
   - Persistent client-side article history caching to IndexedDB (`idb-keyval`) to overcome relay replaceable event pruning.

5. **Svelte 5 & State Fixes**:
   - Fixed a silent `goto` serialization crash by recursively cleaning nested editor previous card data to prevent state proxies from leaking into SvelteKit history.
   - Resolved a layout temporal dead zone by restructuring reactive derived state definitions.